### PR TITLE
update links to morning challenges and workshops in all weekly schedules

### DIFF
--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -23,12 +23,12 @@
 — LUNCH —
 - 14.00 - 14.50 — Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/pair-programming.md)
 - 14:50 - 15:00 — Toilet/Coffee Break
-- 15:00 - 16:00 — [Accessibility Workshop](https://github.com/jsms90/web-accessibility)
+- 15:00 - 16:00 — [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility)
 - 16.00 - 18.00 — Business Development / Community Outreach
 
 ## Day 2
-- 10:00 - 11:00 — Morning Challenge - [Accessibility challenge](https://github.com/njsfield/accessibility-challenge)
-- 11:00 - 12:45 — [Git workshop](https://github.com/jsms90/learn-git-basics)
+- 10:00 - 11:00 — Morning Challenge - [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge)
+- 11:00 - 12:45 — [Git workshop](https://github.com/NataliaLKB/learn-git-basics)
 - 12:45 - 13:00 — Introduce [Research topics](./research-afternoon.md)
 
 — LUNCH —
@@ -37,7 +37,7 @@
 - 17:30 - 18:00 — Introduce [Project](./project.md)
 
 ## Day 3
-- 10.00 - 11.00 — [Morning Challenge - CSS Gallery Challenge](https://github.com/njsfield/css-gallery-challenge)
+- 10.00 - 11.00 — [Morning Challenge - CSS Gallery Challenge](https://github.com/foundersandcoders/css-gallery-challenge)
 - 11.00 - 13.00 — Projects
 
 — LUNCH —

--- a/coursebook/week-2/README.md
+++ b/coursebook/week-2/README.md
@@ -11,7 +11,7 @@
 ### Monday
 
 - 10:00 - 11:00 <br>
-[Intro to testing and QUnit](https://github.com/skibinska/learn-qunit) - [Fizz Buzz](https://github.com/skibinska/fizzbuzz)
+[Intro to testing and QUnit](https://github.com/foundersandcoders/learn-qunit) - [Fizz Buzz](https://github.com/foundersandcoders/fizzbuzz)
 
 - 11:00 - 13:00 <br>
 [DWYL Test Driven Development (TDD) workshop](https://github.com/dwyl/learn-tdd)
@@ -19,7 +19,7 @@
 — LUNCH —
 
 - 14:00 - 16:00 <br>
-Pair programming, ping pong [roman numeral challenge](https://github.com/skibinska/romanizer)
+Pair programming, ping pong [roman numeral challenge](https://github.com/foundersandcoders/romanizer)
 
 - 16:00 - 18:00 <br>
 Business development / community engagement

--- a/coursebook/week-3/README.md
+++ b/coursebook/week-3/README.md
@@ -13,9 +13,9 @@
 
 - 10.00 - 10.15 <br /> Introduction and learning outcomes with week-3 mentors  
 
-- 10.15 - 12.00 <br /> [Introductory workshop](https://github.com/lucymonie/api-workshop): API basics, HTTP, XHMLHttp requests, request-response pattern
+- 10.15 - 12.00 <br /> [Introductory workshop](https://github.com/foundersandcoders/api-workshop): API basics, HTTP, XHMLHttp requests, request-response pattern
 
-- 12.00 - 13.00 <br /> [XHR workshop](https://github.com/skibinska/xhr-workshop)
+- 12.00 - 13.00 <br /> [XHR workshop](https://github.com/foundersandcoders/xhr-workshop)
 
 -- LUNCHTIME 😋 --  
 
@@ -27,7 +27,7 @@
 #### DAY 2
 
 - 10.00 - 13.00 <br />
- @eliascodes's [workshop](https://github.com/eliascodes/workshop-client-side-design) on designing for the client (StackOverflow reputation builder)
+ @eliascodes's [workshop](https://github.com/foundersandcoders/workshop-client-side-design) on designing for the client (StackOverflow reputation builder)
 
 -- LUNCHTIME 😋 --  
 
@@ -37,7 +37,7 @@
 
 #### DAY 3
 
-- 10.00 - 11.00 <br /> ['parallel'](/coursebook/week-3/morning-challenge.md) morning challenge
+- 10.00 - 11.00 <br /> [Parallel function morning challenge (version given to FACN1)](/coursebook/week-3/morning-challenge.md) morning challenge | [Parallel function morning challenge (version given to FAC10)](https://github.com/emilyb7/parallel-challenge-github)
 
 - 11.00 - 13.00 <br /> Project Planning  
 

--- a/coursebook/week-4/README.md
+++ b/coursebook/week-4/README.md
@@ -6,7 +6,7 @@
 
 - 10:00 - 13:00
 -- Intro to servers and Node.js
-& [Node Intro Workshop](https://github.com/bradreeder/Node-Intro-Workshop)
+& [Node Intro Workshop](https://github.com/foundersandcoders/Node-Intro-Workshop)
 
 - 14:00 - 16:00
 -- [Node Girls workshop](https://github.com/node-girls/workshop-cms) (CMS steps at the end are *optional*) -   

--- a/coursebook/week-5/README.md
+++ b/coursebook/week-5/README.md
@@ -6,17 +6,19 @@
 
 - 10:00 - 10:15 - Intro to Node week 2
 
-- 10:15 - 13:00 - [Workshop on TDD Node server using Shot and Tape](https://github.com/njsfield/tdd-node-server-with-shot-and-tape)
+- 10:15 - 13:00 - [Workshop on TDD Node server using Shot and Tape](https://github.com/foundersandcoders/tdd-node-server-with-shot-and-tape)
 
 — LUNCH —
 
-- 14:00 - 16:00 - [Workshop on error handling & testing for errors](https://github.com/njsfield/error-handling-workshop)
+- 14:00 - 16:00 - [Workshop on error handling & testing for errors](https://github.com/foundersandcoders/error-handling-workshop)
 
 - 16:00 - 18:00 - Business development
 
 #### Day 2
 
-- 10:00 - 12:45 - [Node shell workshop](https://github.com/msachi/Node-Shell-Workshop)
+- 10:00 - 12:45 - [Node shell workshop](https://github.com/msachi/Node-Shell-Workshop)  
+THIS VERSION SHOULD NOT BE ITERATED UPON. It is a copy of previously existing material from 2 other workshops.  
+This exists here so that you can look through the version as it was delivered to you. For iterations, please use the original.
 
 - 12:45 - 13:00 - Introduce [research topics](./research-afternoon.md)
 

--- a/coursebook/week-6/README.md
+++ b/coursebook/week-6/README.md
@@ -12,15 +12,15 @@ Then go to [pgexercises](https://www.pgexercises.com/gettingstarted.html) and wo
 
 1pm - 2pm: lunchtime 😋
 
-2pm - 4.30pm: [workshop on SQL commands and psql](https://github.com/FAC9/postgres-workshop). We will go through this together and first and then work in pairs.
+2pm - 4.30pm: [workshop on SQL commands and psql](https://github.com/foundersandcoders/postgres-workshop). We will go through this together and first and then work in pairs.
 
 4.30pm - 6pm: biz dev and community outreach
 
 #### Day 2:
 
-10am - 11am: [intro to pg module](https://github.com/shiryz/pg-walkthrough)
+10am - 11am: [intro to pg module](https://github.com/foundersandcoders/pg-walkthrough)
 
-11am - 1pm: [workshop on making small node app with a database connection](https://github.com/shiryz/pg-workshop)
+11am - 1pm: [workshop on making small node app with a database connection](https://github.com/foundersandcoders/pg-workshop)
 
 1pm - 2pm: lunchtime 😋
 
@@ -30,7 +30,7 @@ Then go to [pgexercises](https://www.pgexercises.com/gettingstarted.html) and wo
 
 #### Day 3
 
-10am - 11am: [morning challenge](https://github.com/shiryz/db-morning-challenge)
+10am - 11am: [morning challenge](https://github.com/foundersandcoders/db-morning-challenge)
 
 11am onwards: projects
 

--- a/coursebook/week-7/README.md
+++ b/coursebook/week-7/README.md
@@ -6,13 +6,13 @@
 
 - 10:00 - 10:15 - [Intro](./summary.md) to hapi.js and libraries / frameworks
 
-- 10:15 - 11:15 - Hapi Server & Inert [code-along](https://github.com/msachi/hapi-intro)
+- 10:15 - 11:15 - Hapi Server & Inert [code-along](https://github.com/foundersandcoders/hapi-intro)
 
 - 11:15 - 13:00 - [Make me hapi workshop](./makemehapi-guidelines.md)
 
 — LUNCH —
 
-- 14:00 - 16:00 - Hapi Vision & Handlebars [walk-through](https://github.com/marisid/handlebars-intro-workshop)
+- 14:00 - 16:00 - Hapi Vision & Handlebars [walk-through](https://github.com/foundersandcoders/handlebars-intro-workshop)
 
 - 16:00 - 18:00 - Business development
 


### PR DESCRIPTION
+ update links to ensure they are pointing to the correct version of the workshop - original or under `foundersandcoders`
+ add @emilyb7's last minute 2nd version of the parallel function morning challenge
+ add a note to the Node Shell workshop, indicating that students shouldn't iterate on the version that was delivered to them. Instead they should use the original repo(s), as per the request of the original author.  
This may or may not become relevant, depending on the decision taken on proposal #190 

relates #271 #205