### PR TITLE
list weeks & parts in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A master reference for the running of [Founders &amp; Coders](http://www.foundersandcoders.org), including the curriculum.
 
-**All pull requests welcome** Checkout our [contribution guidelines](https://github.com/foundersandcoders/master-reference/blob/master/CONTRIBUTING.md).
+**All pull requests welcome**. Checkout our [contribution guidelines](https://github.com/foundersandcoders/master-reference/blob/master/CONTRIBUTING.md).
 
 ## Curriculum
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,101 @@ A master reference for the running of [Founders &amp; Coders](http://www.founder
 A curriculum can be thought of as the ordered collection of weeks that students will follow at a given campus. Likewise a week can be thought of as an ordered collection of parts (i.e. a workshop, morning challenge, set of research topics or project).
 
 Below is a list of potential weeks, that might make up a curriculum, and each one's possible parts.
+
+### Toolkit
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-toolkit)
+
+#### Morning challenges
+* [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge)
+* [CSS Gallery Challenge](https://github.com/foundersandcoders/css-gallery-challenge)
+
+#### Workshops
+* [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility)
+* [Learn git basics](https://github.com/NataliaLKB/learn-git-basics)
+* [Git workflow workshop for two](https://github.com/foundersandcoders/git-workflow-workshop-for-two)
+
+### Testing
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-testing)
+
+#### Morning challenges
+* [Waterfall function](https://github.com/RhodesPeter/waterfall-function-workshop)
+* [DOM manipulation](https://github.com/mantagen/DOM-manipulation-Challenge)
+
+#### Workshops
+* [Intro to testing and QUnit](https://github.com/foundersandcoders/learn-qunit)
+* [Fizz Buzz](https://github.com/foundersandcoders/fizzbuzz)
+* [DWYL Test Driven Development (TDD) workshop](https://github.com/dwyl/learn-tdd)
+* [Roman Numerals workshop](https://github.com/foundersandcoders/romanizer)
+
+### APIs
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-API)
+
+#### Morning challenges
+* [Parallel function](./coursebook/week-3/morning-challenge.md)
+* [Parallel function - GitHub version](https://github.com/emilyb7/parallel-challenge-github)
+
+#### Workshops
+* [Intro to APIs - read + Q&A](https://github.com/foundersandcoders/api-workshop)
+* [XHR workshop](https://github.com/foundersandcoders/xhr-workshop)
+* [API workshop](https://github.com/emilyb7/workshop-APIs)
+* [Client-side design workshop](https://github.com/foundersandcoders/workshop-client-side-design)
+
+### Node 1
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-node-1)
+
+#### Morning challenges
+* [Convert ES6 code to ES5](https://github.com/stevehopkinson/es6-challenge.git)
+* [Modularise a simple Node.js server](https://github.com/foundersandcoders/modules-challenge)
+
+#### Workshops
+* [Node Intro Workshop](https://github.com/foundersandcoders/Node-Intro-Workshop)
+* [Node Girls CMS workshop](https://github.com/node-girls/workshop-cms)
+* [Tape-testing Workshop](https://github.com/matthewglover/tape-testing)
+
+### Node 2
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-node-2)
+
+#### Morning challenges
+* [Build Request module](https://github.com/RhodesPeter/request-module-workshop)
+
+#### Workshops
+* [TDD Node server using Shot and Tape](https://github.com/foundersandcoders/tdd-node-server-with-shot-and-tape)
+* [Error handling & testing for errors](https://github.com/foundersandcoders/error-handling-workshop)
+* [Node shell workshop](https://github.com/msachi/Node-Shell-Workshop)
+
+### Postgres
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-postgres)
+
+#### Morning challenges
+* [Queries, joins and subqueries](https://github.com/foundersandcoders/db-morning-challenge)
+
+#### Workshops
+* [Installation workshop](https://github.com/dwyl/learn-postgresql)
+* [SQL commands and psql](https://github.com/foundersandcoders/postgres-workshop)
+* [Making small node app with a database connection](https://github.com/foundersandcoders/pg-workshop)
+
+### Authentication
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-authentication)
+
+### Hapi 1
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-hapi-template)
+
+#### Morning challenges
+* [Handlebars challenge](https://github.com/Jbarget/handlebars-morning-challenge)
+* [Setting a cookie](https://github.com/SavageWilliam/hapi-auth-cookie-ws)
+
+#### Workshops
+* [Code-along intro to hapi](https://github.com/foundersandcoders/hapi-intro)
+* [Make me hapi](./makemehapi-guidelines.md)
+* [Handlebars walk-through](https://github.com/foundersandcoders/handlebars-intro-workshop)
+
+### Hapi 2
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-hapi-auth)
+
+#### Workshops
+* [OAuth workshop](https://github.com/foundersandcoders/oauth)
+* [hapi Authentication workshop](https://github.com/foundersandcoders/hapi-authentication-workshop)
+* [JWT workshop](https://github.com/foundersandcoders/jwt_workshop)
+
+### Express
+[Open issues](https://github.com/foundersandcoders/master-reference/issues?q=is%3Aopen+is%3Aissue+label%3Aweek-express)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 A master reference for the running of [Founders &amp; Coders](http://www.foundersandcoders.org), including the curriculum.
 
 **All pull requests welcome** Checkout our [contribution guidelines](https://github.com/foundersandcoders/master-reference/blob/master/CONTRIBUTING.md).
+
+## Curriculum
+
+A curriculum can be thought of as the ordered collection of weeks that students will follow at a given campus. Likewise a week can be thought of as an ordered collection of parts (i.e. a workshop, morning challenge, set of research topics or project).
+
+Below is a list of potential weeks, that might make up a curriculum, and each one's possible parts.

--- a/vision.md
+++ b/vision.md
@@ -9,18 +9,12 @@ This is a draft. Along with some of my (@des-des's) ideas, some of this has come
  * To supply a set of resources that can be used to build a curriculum.
  * To allow a single point of collaboration between campuses without impeding on the autonomy of any one campus
 
-## Glossary of Terms
 
- * *Curriculum*: An ordered collection of *week*s that will make up the curriculum students will follow at a campus.
- * *Week*: A ordered collection of *part*s that will take 5 days to complete.
- * *Part*: One of: a workshop, a research afternoon, a morning challenge, a talk or a project.
+## Implementation
+ * Some *part*s will live outside of the master reference. For now these are workshops and morning challenges. Weeks and the other parts will live inside the master reference.
 
+ * Each week and part should have clear **learning outcomes** and  **prerequisites**. These should have the same format so that mentors can make sure the prerequisites of any given task have been covered in the learning outcomes of previously undertaken tasks.
 
- ## Implementation
-  * Some *part*s will live outside of the master reference. For now these are workshops and morning challenges. Weeks and the other parts will live inside the master reference.
+ * The level of crossover between two different campuses is at the discretion of those campuses.
 
-  * Each week and part should have clear **learning outcomes** and  **prerequisites**. These should have the same format so that mentors can make sure the prerequisites of any given task have been covered in the learning outcomes of previously undertaken tasks.
-
-  * The level of crossover between two different campuses is at the discretion of those campuses.
-
-  * Any week / curriculum can be easily reassembled. The final curriculum of any single campus will live in a repository belonging to a campus.
+ * Any week / curriculum can be easily reassembled. The final curriculum of any single campus will live in a repository belonging to a campus.


### PR DESCRIPTION
+ move definitions of "curriculum", "week" and "part" from `vision.md` to the readme
+ list all weeks
+ link to the open issues under each week's label
+ list all morning challenges & workshops under each week

Relates #216 #155 #137 