### PR TITLE
Make refs to cohorts/locations consistent

### DIFF
--- a/coursebook/general/retrospectives.md
+++ b/coursebook/general/retrospectives.md
@@ -20,13 +20,13 @@ The feedback can range broadly from environmental concerns, to timetabling, to f
 
 Once students have filled a whiteboard with their feedback, an assigned facilitator will read each point and they are discussed by the group. Every student votes at the end on a single "stop", "go", and "continue" item they consider the highest priority. The points with the most votes are then recorded as key action points.
 
-The minutes of these meetings are captured ([London](https://github.com/foundersandcoders/london-curriculum), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum)), forwarded to mentors of future weeks, and used when we come to prepare for the next curriculum so that we can improve it as a group.
+The minutes of these meetings are captured ([London](https://github.com/foundersandcoders/london-curriculum), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum), [Gaza](https://github.com/foundersandcoders/gaza-curriculum/tree/master/_stop-go-continue)), forwarded to mentors of future weeks, and used when we come to prepare for the next curriculum so that we can improve it as a group.
 
 ## Team retrospectives
 
 We also run a smaller "stop go continue" meeting with each [student team](./teams.md) so they are able to reflect on how their group project work went that week.
 
-At the end, each team member votes on three "stop" or "go" items they consider the highest priority. The three items with the most votes are then recorded, and taken forward as goals for the following week. Goals of prior weeks, and recurring items, are revisited in each project retrospective. Again, these are stored for reference in the respective curriculum repos: [London](https://github.com/foundersandcoders/london-curriculum), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum).
+At the end, each team member votes on three "stop" or "go" items they consider the highest priority. The three items with the most votes are then recorded, and taken forward as goals for the following week. Goals of prior weeks, and recurring items, are revisited in each project retrospective. Again, these are stored for reference in the respective curriculum repos: [London](https://github.com/foundersandcoders/london-curriculum), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum), [Gaza](https://github.com/foundersandcoders/gaza-curriculum).
 
 ### The Prime Directive
 

--- a/coursebook/general/weekly-projects.md
+++ b/coursebook/general/weekly-projects.md
@@ -10,7 +10,7 @@ The teams stay together for the following weeks:
 Your mentors will let you know which teams you will be in at the beginning of weeks: 1, 4 & 7. Have a chat with your team when it first forms, and come up with a team name.
 
 ## Creating repositories for each project
-Inside your GitHub organisation - [London](https://github.com/FAC10), [Nazareth](https://github.com/FACN1) - you will see three repositories that have been created for you:
+Inside your GitHub organisation you will see three repositories that have been created for you:
 + `prerequisites-gh-pages`
 + `research`
 + `morning-challenge-solutions`

--- a/coursebook/week-3/README.md
+++ b/coursebook/week-3/README.md
@@ -5,7 +5,7 @@
 * [Learning outcomes](/coursebook/week-3/learning-outcomes.md)
 * [Projects](/coursebook/week-3/project.md)
 * [Resources](/coursebook/week-3/resources.md)
-* stop-go-continue [London](https://github.com/foundersandcoders/london-curriculum/blob/master/stop-go-continue/fac-10/week-3.md)  [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum/tree/master/stop-go-continue/fac-n1)
+* Stop-Go-Continue: [London](https://github.com/foundersandcoders/london-curriculum/blob/master/stop-go-continue/fac-10/week-3.md), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum/tree/master/stop-go-continue/fac-n1), [Gaza](https://github.com/foundersandcoders/gaza-curriculum/tree/master/_stop-go-continue)
 
 ### Schedule
 

--- a/coursebook/week-5/README.md
+++ b/coursebook/week-5/README.md
@@ -60,7 +60,7 @@ This exists here so that you can look through the version as it was delivered to
 
 — LUNCH —
 
-- 14:00 - 15:00 - [Group stop-go-continue](https://github.com/foundersandcoders/london-curriculum/tree/master/stop-go-continue) (Course Coordinator, current week mentors, week 2 mentors)
+- 14:00 - 15:00 - Group Stop-Go-Continue: [London](https://github.com/foundersandcoders/london-curriculum/tree/master/stop-go-continue), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum/tree/master/stop-go-continue), [Gaza](https://github.com/foundersandcoders/gaza-curriculum/tree/master/_stop-go-continue) (Course Coordinator, current week mentors, week 2 mentors)
 
 - 15:00 - 16:20 - Presentations (1+ current week mentors, 1+ week 2 mentors)
 

--- a/coursebook/week-6/README.md
+++ b/coursebook/week-6/README.md
@@ -55,4 +55,4 @@ Continue work on projects
 
 4.30pm - 5.30pm classroom stop-go-continue
 
-5.30pm - home time, pub
+5.30pm - home time!

--- a/coursebook/week-6/README.md
+++ b/coursebook/week-6/README.md
@@ -55,4 +55,4 @@ Continue work on projects
 
 4.30pm - 5.30pm classroom stop-go-continue
 
-5.30pm - home time, pub, whatever you do in Nazareth
+5.30pm - home time, pub

--- a/coursebook/week-6/project.md
+++ b/coursebook/week-6/project.md
@@ -46,7 +46,7 @@ As a member of or visitor to Founders & Coders...
 * I can add a rating/review of an existing place
 
 Suggested additional requirements / stretch goals:
-* Multiple locations (e.g. Bethnal Green and Nazareth!)
+* Multiple locations
 * Show the location with Google Maps
 
 #### Founders & Coders events calendar

--- a/coursebook/week-7/README.md
+++ b/coursebook/week-7/README.md
@@ -62,7 +62,7 @@
 
 — LUNCH —
 
-- 14:00 - 15:00 - [Group stop-go-continue](https://github.com/foundersandcoders/london-curriculum/tree/master/stop-go-continue) (Course Coordinator, current week mentors, week 2 mentors)
+- 14:00 - 15:00 - Group Stop-Go-Continue: [London](https://github.com/foundersandcoders/london-curriculum/tree/master/stop-go-continue), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum/tree/master/stop-go-continue), [Gaza](https://github.com/foundersandcoders/gaza-curriculum/tree/master/_stop-go-continue) (Course Coordinator, current week mentors, week 2 mentors)
 
 - 15:00 - 16:20 - Presentations (1+ current week mentors, 1+ week 2 mentors)
 


### PR DESCRIPTION
Fixes #361 

I'm proposing the removal of explicit references to cohorts and locations from the coursebook part of the master-reference as far as possible. Where it's not possible, all locations should be included.

This is partly to reduce the maintenance burden, and also because it's not nice for Gaza (or any other future locations) to see Lon/Naz as a pair everywhere.

Already suggested some changes in #345 