### PR TITLE
Updated day1 schedule

### DIFF
--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -5,7 +5,7 @@
 - [Research topics](./research-afternoon.md)
 - [Project](./project.md)
 - [Resources](./resources.md)
-- Stop Go Continue: [London](https://github.com/foundersandcoders/london-curriculum/tree/master/stop-go-continue), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum/tree/master/stop-go-continue)
+
 
 
 ## Day 1
@@ -14,7 +14,9 @@
 - 11:30 - 11:40 - Toilet/Coffee Break
 - 11:40 - 12:10 - Talk on consensus
 - 12:10 - 13.00 — Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/pair-programming.md)
+
 — LUNCH —
+
 - 14:00 - 14:50 — Course overview (1 mentor & Course Coordinator)
   - [Code of Conduct](https://github.com/foundersandcoders/master-reference/blob/master/code_of_conduct.md)
   - [House rules](../general/house-rules.md)
@@ -52,7 +54,7 @@
 - 12.45 - 13.00 — Plan presentations
 
 — LUNCH —
-- 14.00 - 15.00 — [Group stop-go-continue](https://github.com/foundersandcoders/london-curriculum/tree/master/stop-go-continue) (Course Coordinator, current week mentors, week 2 mentors)
+- 14.00 - 15.00 — Group stop-go-continue (Course Coordinator, current week mentors, week 2 mentors)
 - 15.00 - 16.20 — Presentations (1+ current week mentors, 1+ week 2 mentors)
 - 16.20 - 17.00 — Team stop-go-continue (Course Coordinator)
 - 17.00 - 18.00 — Project Demo from alumni / External speaker

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -9,19 +9,15 @@
 
 
 ## Day 1
-- 10.00 - 11.00 — Introduction & Name game  
-(As many members of Founders and Coders as possible! Directors, Course Coordinator, previous cohort & other alumni)
-- 11.00 - 11.30 — [Welcome talk](https://github.com/foundersandcoders/master-reference/blob/master/about.md) (Directors)
-- 11.30 - 13.00 — Course overview (1 mentor & Course Coordinator)
-    - [Code of Conduct](https://github.com/foundersandcoders/master-reference/blob/master/code_of_conduct.md)
-    - [House rules](../general/house-rules.md)
-    - [Becoming a mentor](../general/tips-for-mentoring.md) - [contributing to the `master reference`](https://github.com/foundersandcoders/master-reference/blob/master/CONTRIBUTING.md)
-    - [Future membership to Founders and Coders](https://github.com/foundersandcoders/london-programme/blob/master/membership.md)
-    - Campus-specific information - [London](https://github.com/foundersandcoders/london-curriculum), [Nazareth](https://github.com/foundersandcoders/nazareth-curriculum)
-    - Structure of Github organisation & repositories - [London](https://github.com/FAC10), [Nazareth](https://github.com/FACN1) (1 mentor & Course Coordinator)
-
+- 10.00 - 10.30 — [Welcome talk](https://github.com/foundersandcoders/master-reference/blob/master/about.md) (Directors)
+- 10:30 - 11:30 — Name game with as many members of Founders and Coders as possible!
+- 11:30 - 11:40 - Toilet/Coffee Break
+- 11:40 - 12:10 - Talk on consensus
+- 12:10 - 13.00 — Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/pair-programming.md)
 — LUNCH —
-- 14.00 - 14.50 — Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/pair-programming.md)
+- 14:00 - 14:50 — Course overview (1 mentor & Course Coordinator)
+  - [Code of Conduct](https://github.com/foundersandcoders/master-reference/blob/master/code_of_conduct.md)
+  - [House rules](../general/house-rules.md)
 - 14:50 - 15:00 — Toilet/Coffee Break
 - 15:00 - 16:00 — [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility)
 - 16.00 - 18.00 — Business Development / Community Outreach

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -37,8 +37,8 @@
 - 11.00 - 13.00 — Projects
 
 — LUNCH —
-- 14.00 - 17.00 — Projects
-- 17.00 - 18.00 — FAC Values talk
+- 14.00 - 17.30 — Projects
+- 17.30 - 18.00 — FAC Values talk
 
 ## Day 4
 - 10.00 - 13.00 — Projects


### PR DESCRIPTION
Reduced the time slot for the Fac values talk from 1 hour to 30 mins, 
fixes #333 
Moved the pair-programming slot to the morning and introduced a talk on consensus, which has now been placed in the morning as well,
fixes #338 
Moved the Course overview talk to the afternoon,
fixes #367
