### PR TITLE
remove London reference to 'upstairs' from general week schedule

### DIFF
--- a/coursebook/general/week-schedule.md
+++ b/coursebook/general/week-schedule.md
@@ -66,4 +66,4 @@ Start each week with a mission and a goal.
 
 16:20-17:00 - Team Retrospectives (Team S-G-C)
 
-17:00-18:00 - External Speaker or Upstairs Project
+17:00-18:00 - External Speaker or Alumni Project Presentation


### PR DESCRIPTION
Change "upstairs project" to "alumni project" in general week schedule so it isn't so London-centric

fixes #379