### PR TITLE
update presentation planning bullet points & link in week 1 schedule

### DIFF
--- a/coursebook/general/weekly-projects.md
+++ b/coursebook/general/weekly-projects.md
@@ -41,16 +41,11 @@ Each team then has 15 minutes to present, with 5 minutes for questions. We will 
 
 ### Structure
 1. Show your readme:
-  + Why, What, How
+    + Talk through the Why, What, How of your project
     + How did you split up the work?
     + How did you choose to pair?
-2. Show your use of Github
-  + commit history
-  + PR history
-3. Walk us through the UX (user experience) i.e. demo your website
-  + how well does it conform to your brief - the user stories
-4. Walk us through your code:
-  + talk us through your chosen file structure
-  + code itself: prioritise the things you learned that were new to you, which the rest of your cohort could benefit from hearing about:
-    + something you're proud of, that was really cool
+2. Walk us through the UX (user experience) i.e. demo your website
+    + How well does it conform to your brief - the user stories
+3. Walk us through your code. Prioritise the things you learned that were new to you, which the rest of your cohort could benefit from hearing about:
+    + something you're proud of
     + something that you found really hard / struggled with

--- a/coursebook/general/weekly-projects.md
+++ b/coursebook/general/weekly-projects.md
@@ -44,8 +44,7 @@ Each team then has 15 minutes to present, with 5 minutes for questions. We will 
     + Talk through the Why, What, How of your project
     + How did you split up the work?
     + How did you choose to pair?
-2. Walk us through the UX (user experience) i.e. demo your website
-    + How well does it conform to your brief - the user stories
+2. Demo your website and explain how it conforms to your brief i.e. the user stories
 3. Walk us through your code. Prioritise the things you learned that were new to you, which the rest of your cohort could benefit from hearing about:
     + something you're proud of
     + something that you found really hard / struggled with

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -51,7 +51,7 @@
 ## Day 5
 - 10.00 - 11.00 — [Code review](../general/code-reviews.md) (1 alumnus per project)
 - 11.00 - 12.45 — Respond to issues
-- 12.45 - 13.00 — Plan presentations
+- 12.45 - 13.00 — [Plan presentations](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/weekly-projects.md#project-presentation)
 
 — LUNCH —
 - 14.00 - 15.00 — Group stop-go-continue (Course Coordinator, current week mentors, week 2 mentors)


### PR DESCRIPTION
+ Remove "Show your use of Github" - better for mentors just to highlight examples of good practice during Q&A time
+ update presentation planning bullet points
+ add link from week 1 schedule

fixes #404