### PR TITLE
api week - change day 2 to include flexbox froggy & put modular design workshop back in

### DIFF
--- a/coursebook/week-3/README.md
+++ b/coursebook/week-3/README.md
@@ -26,25 +26,20 @@
 
 #### DAY 2
 
-- 10.00 - 11:45 <br />
-[Flexbox Workshop](https://github.com/smarthutza/flexbox-workshop) 
-- 12.00 - 13:00 <br />
+- 10.00 - 11:00 <br />
+[Flexbox Froggy](http://flexboxfroggy.com/)
+- 11.00 - 11:30 <br />
+[Flexbox Dice Morning Challenge](https://github.com/smarthutza/flexbox-workshop)
+- 11.45 - 13.00 <br />
 [Software Architecture Workshop](https://github.com/foundersandcoders/Workshop-Software-Architecture-Design)
-
 
 -- LUNCHTIME 😋 --  
 
-- 14.00 - 15.00 <br /> 
-Software Architecture continues
+- 14.00 - 17.00 <br />
+[Software Design Workshop]()
 
-- 15.00 - 16.30 <br /> 
-[Research](link to be updated)
-
-- 16.30 - 17.30 <br /> 
-Presentations 
-
-- 17.30 - 18.00 <br /> 
-[Introduce projects](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-3/project.md)  
+- 17.15 - 18.00 <br />
+[Introduce Projects](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-3/project.md) & Start Planning Architecture
 
 #### DAY 3
 


### PR DESCRIPTION
Updated Week 3 schedule to reflect the changes we have made to Day Two 
+ add flexbox froggy
+ add @smarthutza's flexbox workshop
+ put @eliascodes' workshop back in, instead of research afternoon
+ add time at the end of the day for students to begin project by implementing software design ideas they have just learned

relates #300