### PR TITLE
 Adjust week schedule in master-reference

### DIFF
--- a/coursebook/week-3/README.md
+++ b/coursebook/week-3/README.md
@@ -26,9 +26,9 @@
 
 #### DAY 2
 
-- 10.00 - 11:00 <br />
+- 10:00 - 10:45 <br />
 [Flexbox Froggy](http://flexboxfroggy.com/)
-- 11.00 - 11:30 <br />
+- 10:45 - 11:45 <br />
 [Flexbox Dice Morning Challenge](https://github.com/smarthutza/flexbox-workshop)
 - 11.45 - 13.00 <br />
 [Software Architecture Workshop](https://github.com/foundersandcoders/Workshop-Software-Architecture-Design)


### PR DESCRIPTION
The new schedule for week3 has now been update. Flexbox Froggy takes 15 minutes less and the dice challenge 15 minutes more than initially planned. 
Fix #474