### PR TITLE
clarify contributing guidelines - commit & PR ettiquette including who to add as assignees & reviewers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,6 @@ Inspired by [dwyl's contribution workflow](https://www.github.com/dwyl/contribut
 
 ## Starting work
 
-Please follow [these guidelines on ettiquette](https://gist.github.com/mikepea/863f63d6e37281e329f8), in order to make the most of GitHub as a communication tool :tada:
-
 ### Commits
 The commit history of each file should tell a story
 + [Describe your changes well](https://gist.github.com/mikepea/863f63d6e37281e329f8#describe-your-changes-well-in-each-commit)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Make sure your PR has the following
   1. [A descriptive title](https://gist.github.com/mikepea/863f63d6e37281e329f8#ensure-there-is-a-solid-title-and-summary) - distinct from others and therefore searchable
   2. [A body with details of everything in the pull.](https://gist.github.com/mikepea/863f63d6e37281e329f8#ensure-there-is-a-solid-title-and-summary)
   3. Reference to any/all related issues in description.
-  4. Assignees - add the following people to every PR:
+  4. Assignees - add all the maintainers of `master-reference` to every PR:
     + [@bradreeder](https://github.com/bradreeder)
     + [@des-des](https://github.com/des-des)
     + [@jsms90](https://github.com/jsms90)
@@ -77,6 +77,9 @@ Make sure your PR has the following
     + [@sofer](https://github.com/sofer)
     + [@iteles](https://github.com/iteles)
     + [@nelsonic](https://github.com/nelsonic)
+  5. Reviewers
+    + add anyone other than the maintainers, who you think should be aware of you contents of your PR (e.g. anyone else who has collaborated with you on this issue, anyone mentioned in the file you are uploading)
+    + if your PR _requires_ a review from a particular person / people _before_ it is ready to be merged, specify this within the body of your PR
 
 ## Instructions for maintainers
 Once a pull request has been approved by two maintainers it can be merged. In time critical situations, one approval may suffice, as long a the pull request is small and is not suggesting any major change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 Inspired by [dwyl's contribution workflow](https://www.github.com/dwyl/contributing).
 
-The following people are available to review pull requests: [@bradreeder](https://github.com/bradreeder), [@des-des](https://github.com/des-des), [@jsms90](https://github.com/jsms90), [@eliascodes](https://github.com/eliascodes), [@sofer](https://github.com/sofer), [@iteles](https://github.com/iteles) or [@nelsonic](https://github.com/nelsonic).
-
 # Contribution guidelines
 
 ## Before starting work
@@ -65,7 +63,14 @@ Make sure your PR has the following
   1. [A descriptive title](https://gist.github.com/mikepea/863f63d6e37281e329f8#ensure-there-is-a-solid-title-and-summary) - distinct from others and therefore searchable
   2. [A body with details of everything in the pull.](https://gist.github.com/mikepea/863f63d6e37281e329f8#ensure-there-is-a-solid-title-and-summary)
   3. Reference to any/all related issues in description.
-  4. Assignees, assign between two and three of the designated maintainers.
+  4. Assignees - add the following people to every PR:
+    + [@bradreeder](https://github.com/bradreeder)
+    + [@des-des](https://github.com/des-des)
+    + [@jsms90](https://github.com/jsms90)
+    + [@eliascodes](https://github.com/eliascodes)
+    + [@sofer](https://github.com/sofer)
+    + [@iteles](https://github.com/iteles)
+    + [@nelsonic](https://github.com/nelsonic)
 
 ## Instructions for maintainers
 Once a pull request has been approved by two maintainers it can be merged. In time critical situations, one approval may suffice, as long a the pull request is small and is not suggesting any major change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@ Inspired by [dwyl's contribution workflow](https://www.github.com/dwyl/contribut
 
 # Contribution guidelines
 
++ [Before starting work](#before-starting-work)
++ [Starting work](#starting-work)
+  + [Commits](#commits)
+  + [Pull requests](pull-requests)
++ [Instructions for maintainers](#instructions-for-maintainers)
+
 ## Before starting work
 
  1. Search this repo's [issues](https://www.github.com/foundersandcoders/master-reference/issues) to see if an issue exists for the problem you are solving.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,8 @@ Make sure your PR has the following
     + [@iteles](https://github.com/iteles)
     + [@nelsonic](https://github.com/nelsonic)
   5. Reviewers
-    + add anyone other than the maintainers, who you think should be aware of you contents of your PR (e.g. anyone else who has collaborated with you on this issue, anyone mentioned in the file you are uploading)
+    + add anyone other than the maintainers, who you think should be aware of you contents of your PR  
+    e.g. anyone else who has collaborated with you on this issue / anyone mentioned in the file you are uploading / mentors delivering this material in another campus
     + if your PR _requires_ a review from a particular person / people _before_ it is ready to be merged, specify this within the body of your PR
 
 ## Instructions for maintainers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,14 +23,17 @@ The following people are available to review pull requests: [@bradreeder](https:
 `question` - you're not actually sure whether this is an issue or not and would like confirmation
 `help wanted` - you would like some help in completing work on this issue
 
-## Commits
+## Starting work
 
+Please follow [these guidelines on ettiquette](https://gist.github.com/mikepea/863f63d6e37281e329f8), in order to make the most of GitHub as a communication tool :tada:
+
+### Commits
 The commit history of each file should tell a story
 + [Describe your changes well](https://gist.github.com/mikepea/863f63d6e37281e329f8#describe-your-changes-well-in-each-commit)
 + [Commits should be granular](https://gist.github.com/mikepea/863f63d6e37281e329f8#keep-it-small)
 + **It is important that you reference an issue in each commit** - use [multiline messages](#multiline-messages)
 
-### Multiline messages
+#### Multiline messages
 
 You will want to space your commit messages over more than one line. Commit without the `-m` to bring up a text editor in which to write the commit message.
 
@@ -53,7 +56,7 @@ short description under 50 chars.
 related #[issue number]
 ```
 
-## Pull Requests
+### Pull Requests
 
 Once you have finished your work, push up your branch and make a pull request. Remember, a pull request should be as small as possible. This makes the review process quick and easy.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,10 @@ The following people are available to review pull requests: [@bradreeder](https:
 
 ## Commits
 
-Remember to keep your commits granular and their messages short but descriptive.
-
-**It is important that you reference an issue in each commit.**
+The commit history of each file should tell a story
++ [Describe your changes well](https://gist.github.com/mikepea/863f63d6e37281e329f8#describe-your-changes-well-in-each-commit)
++ [Commits should be granular](https://gist.github.com/mikepea/863f63d6e37281e329f8#keep-it-small)
++ **It is important that you reference an issue in each commit** - use [multiline messages](#multiline-messages)
 
 ### Multiline messages
 
@@ -54,14 +55,14 @@ related #[issue number]
 
 ## Pull Requests
 
-Once you have finished your work, push up your branch and make a pull request. Make sure it has the following
+Once you have finished your work, push up your branch and make a pull request. Remember, a pull request should be as small as possible. This makes the review process quick and easy.
 
-  1. A good title
-  2. Description, with detail of everything in the pull.
+Make sure your PR has the following
+
+  1. [A descriptive title](https://gist.github.com/mikepea/863f63d6e37281e329f8#ensure-there-is-a-solid-title-and-summary) - distinct from others and therefore searchable
+  2. [A body with details of everything in the pull.](https://gist.github.com/mikepea/863f63d6e37281e329f8#ensure-there-is-a-solid-title-and-summary)
   3. Reference to any/all related issues in description.
   4. Assignees, assign between two and three of the designated maintainers.
-
-A pull request should be as small as possible, this makes the review process fast and easy.
 
 ## Instructions for maintainers
 Once a pull request has been approved by two maintainers it can be merged. In time critical situations, one approval may suffice, as long a the pull request is small and is not suggesting any major change.


### PR DESCRIPTION
Motivated by numerous open issues that relate to clarity around the `CONTRIBUTING.md`, as well as how frequently I have to clarify our contributing guidelines (both verbally and via PRs):
+ https://github.com/foundersandcoders/master-reference/pull/473#issuecomment-314836099
+ https://github.com/foundersandcoders/master-reference/pull/458#issuecomment-314435344
+ https://github.com/foundersandcoders/master-reference/pull/453#issuecomment-314379539
+ https://github.com/foundersandcoders/master-reference/pull/449#issuecomment-314155377
+ https://github.com/foundersandcoders/master-reference/pull/423#issuecomment-312507408
+ https://github.com/foundersandcoders/master-reference/pull/407#issuecomment-312448494

This PR will:
+ remove `The following people are available to review pull requests` & move this list into specific instructions on submitting a PR & who to add as assignees #369 
+ add contents page to top of file, so that students can more easily find the list of maintainers (now that it has moved)
+ add link to [a more detailed explanation of PR etiquette](https://gist.github.com/mikepea/863f63d6e37281e329f8) - #418 #90
+ link to specific sections of the ettiquette document from within the `Commits` and `Pull request` steps for greater clarification on what "a good title" actually means #418 #90
+ specify that students should assign every maintainer to every PR #369 #137 
+ make a clear distinction between "assignees" and "reviewers" and give advice on who to add as reviewers #369

Also relevant: "effective use of the search bar" #316