### PR TITLE
Update SQL week 6 schedule

### DIFF
--- a/coursebook/week-6/README.md
+++ b/coursebook/week-6/README.md
@@ -6,7 +6,7 @@
 
 10am - 11am: whiteboard walkthrough with introduction to the topic of relational databases and SQL
 
-11am - 1pm: [installation workshop](https://github.com/dwyl/learn-postgresql)
+11am - 1pm: [installation instructions](https://github.com/macintoshhelper/learn-sql/blob/master/postgresql/setup.md)
 , those who finish installing can help others with installation problems.
 Then go to [pgexercises](https://www.pgexercises.com/gettingstarted.html) and work through in pairs if time remaining (help each other first)!
 

--- a/coursebook/week-6/README.md
+++ b/coursebook/week-6/README.md
@@ -8,7 +8,7 @@
 
 11am - 1pm: [installation instructions](https://github.com/macintoshhelper/learn-sql/blob/master/postgresql/setup.md)
 , those who finish installing can help others with installation problems.
-Then go to [pgexercises](https://www.pgexercises.com/gettingstarted.html) and work through in pairs if time remaining (help each other first)!
+Then go to [`sql-commands-intro` workshop](https://github.com/foundersandcoders/sql-commands-intro/) and work through in pairs if time remaining (help each other first)!
 
 1pm - 2pm: lunchtime 😋
 

--- a/coursebook/week-6/README.md
+++ b/coursebook/week-6/README.md
@@ -18,7 +18,7 @@ Then go to [`sql-commands-intro` workshop](https://github.com/foundersandcoders/
 
 #### Day 2:
 
-10am - 11am: [intro to pg module](https://github.com/foundersandcoders/pg-walkthrough)
+10am - 11am: [pg module code along](https://github.com/foundersandcoders/pg-walkthrough)
 
 11am - 1pm: [workshop on making small node app with a database connection](https://github.com/foundersandcoders/pg-workshop)
 


### PR DESCRIPTION
- Replace SQL setup link - #288 
- Replace `pgexercises` with new workshop: `sql-commands-intro` - #291
- Rename 'intro to pg module' as 'pg module code along' - #290 