### PR TITLE
add schedule for build sprint

### DIFF
--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -1,4 +1,5 @@
-### Day 6
+## First week
+### Day 1
 10.00 - 10.15 - Introduction to build sprint schedule & [learning outcomes i.e. Agile roles & practices](../learning-outcomes.md)
 
 10.15 - 10.45 - Workflow talk
@@ -10,9 +11,31 @@
 
 -- LUNCH --
 
-14.00 - 18.00 - Build
+14.00 - 16.00 - Build
 
-### Day 7 - 13
+16.00 - 18.00 - Business Development
+
+### Day 2
+10.00 - 10.15 - Stand-up
+
+10.15 - 13.00 - Build
+
+-- LUNCH --
+
+14.00 - 18.00 - Curriculum planning
+
+### Day 3
+10.00 - 10.15 - Stand-up
+
+10.15 - 13.00 - Build
+
+-- LUNCH --
+
+14.00 - 17.00 - Build
+
+17.00 - 18.00 - Speaker
+
+### Day 4
 10.00 - 10.15 - Stand-up
 
 10.15 - 13.00 - Build
@@ -21,8 +44,54 @@
 
 14.00 - 18.00 - Build
 
+### Day 5
+10.00 - 11.00 - Today I Learned
 
-### Day 14
+11.00 - 11.15 - Stand-up
+
+10.15 - 13.00 - Build
+
+-- LUNCH --
+
+14.00 - 16.00 - Build
+
+16.00 - 17.00 - Stop Go Continue
+
+17.00 - 18.00 - Speaker
+
+## Second week
+### Day 6
+10.00 - 10.15 - Stand-up
+
+10.15 - 13.00 - Build
+
+-- LUNCH --
+
+14.00 - 16.00 - Build
+
+16.00 - 18.00 - Business Development
+
+### Day 7
+10.00 - 10.15 - Stand-up
+
+10.15 - 13.00 - Build
+
+-- LUNCH --
+
+14.00 - 18.00 - Curriculum planning
+
+### Day 8
+10.00 - 10.15 - Stand-up
+
+10.15 - 13.00 - Build
+
+-- LUNCH --
+
+14.00 - 17.00 - Build
+
+17.00 - 18.00 - Speaker
+
+### Day 9
 10.00 - 11.00 - Write user interview script
 
 11.00 - 13.00 - Conduct user interviews
@@ -35,7 +104,7 @@
 
 17.30 - 18.00 - [Demo prep](https://github.com/dwyl/process-handbook#sprint-demo-prep)
 
-### Day 15
+### Day 10
 10.00 - 12.30 - [Sprint review](https://github.com/dwyl/process-handbook#the-demo)
 
 12.30 - 13.00 - [Sprint retrospective](https://github.com/dwyl/process-handbook#retrospective)
@@ -45,3 +114,7 @@
 14.00 - 15.00 - [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning) (for next iteration)
 
 15.00 - 16.00 - Create [case studies](https://github.com/foundersandcoders/case-studies)
+
+16.00 - 17.00 - Stop Go Continue
+
+17.00 - 18.00 - Speaker

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -1,6 +1,8 @@
 ### Day 6
 10.00 - 10.15 - Introduction to build sprint schedule & [learning outcomes i.e. Agile roles & practices](../learning-outcomes.md)
 
+10.15 - 10.45 - Workflow talk
+
 ### Day 7 - 14
 This is an opportunity for teams to be more self-directed in their project building. [Choice of tech stack](./tech-choices.md) is entirely up to the team and the decision should be made jointly.
 

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -19,7 +19,7 @@
 
 -- LUNCH --
 
-14.00 - 18.00 - Curriculum planning
+14.00 - 18.00 - Build
 
 ### Day 3
 10.00 - 10.15 - Stand-up

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -56,7 +56,7 @@
 
 ## Second week
 ### Day 6
-10.00 - 11.00 - Today I Learned
+10.00 - 11.00 - [Today I Learned](./today-i-learned.md)
 
 11.00 - 11.15 - Stand-up
 

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -43,3 +43,5 @@
 -- LUNCH --
 
 14.00 - 15.00 - [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning) (for next iteration)
+
+15.00 - 16.00 - Create [case studies](https://github.com/foundersandcoders/case-studies)

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -21,30 +21,19 @@
 
 14.00 - 18.00 - Build
 
+
 ### Day 14
-**Morning**  
--- Recap from UX week / Intro for FACN1 --
-+ How to conduct user testing
-  + [Video: How to do a user interview (from Google Ventures updated)](https://www.youtube.com/watch?v=Qq3OiHQ-HCU)
-  + [Article: 5 steps to create good user interview questions](https://medium.com/interactive-mind/5-steps-to-create-good-user-interview-questions-by-metacole-a-comprehensive-guide-8a591b0e2162)
-  + [FAC9 tips](https://github.com/FAC9/future-leaders/blob/d12df8559d7464dbc7be509aedea413f9064faca/docs/user-testing-advice.md)
+10.00 - 11.00 - Write user interview script
 
--- Main portion --
-+ Plan your script/questions in your team
-+ **Conduct user testing**  
-  + OUTSIDE THE SPACE  
-  + [Bring people in](https://gist.github.com/njsfield/cad2904e0fa3a74b32fd5accbca50c2e)
-Aim to speak to 4-5 people
+11.00 - 13.00 - Conduct user interviews
 
-**Afternoon**
-+ Presentation planning (incorporating the user feedback)
-  + Briefly go over the idea, as it was defined during the pitch / sprint planning
-  + Demonstrate the existing features, specifically mentioning how well the initial users stories were met  
-  (Think: sprint review that your dev team might do for the PO, or a presentation that the PO might use for further funding)
-  + Describe the next features you would implement  
-  (What did you learn from user testing & how can that inform your next sprint?)
-  + Open up to Q&A from the rest of the cohort
-  + Follow up by describing one technical challenge & one non-technical challenge that your team faced
+-- LUNCH --
+
+13.00 - 16.00 - Conduct user interviews
+
+16.00 - 17.00 - Synthesise user interview results
+
+17.30 - 18.00 - [Demo prep](https://github.com/dwyl/process-handbook#sprint-demo-prep)
 
 ### Day 15
 10.00 - 12.30 - [Sprint review](https://github.com/dwyl/process-handbook#the-demo)

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -45,9 +45,7 @@
 14.00 - 18.00 - Build
 
 ### Day 5
-10.00 - 11.00 - Today I Learned
-
-11.00 - 11.15 - Stand-up
+10.00 - 10.15 - Stand-up
 
 10.15 - 13.00 - Build
 
@@ -61,7 +59,9 @@
 
 ## Second week
 ### Day 6
-10.00 - 10.15 - Stand-up
+10.00 - 11.00 - Today I Learned
+
+11.00 - 11.15 - Stand-up
 
 10.15 - 13.00 - Build
 

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -4,14 +4,11 @@
 
 10.15 - 10.45 - Workflow talk
 
-10.45 - 12.00 - [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning)
-(Note: you may want to factor in technical spikes to your build time estimates, depending on your [choice of tech stack](./tech-choices.md))
-
-12:00 - 13:00 - Build
+10.45 - 13.00 - [Plan & set up](./preparing-for-build-sprint.md)
 
 -- LUNCH --
 
-14.00 - 16.00 - Build
+14.00 - 16.00 - [Continue planning & setting up](./preparing-for-build-sprint.md)
 
 16.00 - 18.00 - Business Development
 

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -1,5 +1,5 @@
 ### Day 6
-Pitch ideas
+10.00 - 10.15 - Introduction to build sprint schedule & [learning outcomes i.e. Agile roles & practices](../learning-outcomes.md)
 
 ### Day 7 - 14
 This is an opportunity for teams to be more self-directed in their project building. [Choice of tech stack](./tech-choices.md) is entirely up to the team and the decision should be made jointly.

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -1,10 +1,10 @@
 ## First week
 ### Day 1
-10.00 - 10.15 - Introduction to build sprint schedule & [learning outcomes i.e. Agile roles & practices](../learning-outcomes.md)
+10.00 - 10.30 - Introduction to build sprint schedule & [learning outcomes i.e. Agile roles & practices](../learning-outcomes.md)
 
-10.15 - 10.45 - Workflow talk
+10.30 - 11.30 - Workflow talk
 
-10.45 - 13.00 - [Plan & set up](./preparing-for-build-sprint.md)
+11.30 - 13.00 - [Plan & set up](./preparing-for-build-sprint.md)
 
 -- LUNCH --
 

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -89,13 +89,13 @@
 17.00 - 18.00 - Speaker
 
 ### Day 9
-10.00 - 11.00 - Write user interview script
+10.00 - 11.00 - [Planning & scripting user interviews](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/weeks-10-12/user-testing.md#1-planning)
 
-11.00 - 13.00 - Conduct user interviews
+11.00 - 13.00 - [Conduct user interviews](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/weeks-10-12/user-testing.md#3-test-day-pre-test)
 
 -- LUNCH --
 
-13.00 - 16.00 - Conduct user interviews
+13.00 - 16.00 - [Conduct user interviews (continued)](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/weeks-10-12/user-testing.md#3-test-day-pre-test)
 
 16.00 - 17.00 - Synthesise user interview results
 

--- a/coursebook/weeks-10-12/build-sprint/README.md
+++ b/coursebook/weeks-10-12/build-sprint/README.md
@@ -3,10 +3,25 @@
 
 10.15 - 10.45 - Workflow talk
 
-### Day 7 - 14
-This is an opportunity for teams to be more self-directed in their project building. [Choice of tech stack](./tech-choices.md) is entirely up to the team and the decision should be made jointly.
+10.45 - 12.00 - [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning)
+(Note: you may want to factor in technical spikes to your build time estimates, depending on your [choice of tech stack](./tech-choices.md))
 
-### Day 15
+12:00 - 13:00 - Build
+
+-- LUNCH --
+
+14.00 - 18.00 - Build
+
+### Day 7 - 13
+10.00 - 10.15 - Stand-up
+
+10.15 - 13.00 - Build
+
+-- LUNCH --
+
+14.00 - 18.00 - Build
+
+### Day 14
 **Morning**  
 -- Recap from UX week / Intro for FACN1 --
 + How to conduct user testing
@@ -30,5 +45,12 @@ Aim to speak to 4-5 people
   (What did you learn from user testing & how can that inform your next sprint?)
   + Open up to Q&A from the rest of the cohort
   + Follow up by describing one technical challenge & one non-technical challenge that your team faced
-+ Deliver presentations
-+ Stop go continue
+
+### Day 15
+10.00 - 12.30 - [Sprint review](https://github.com/dwyl/process-handbook#the-demo)
+
+12.30 - 13.00 - [Sprint retrospective](https://github.com/dwyl/process-handbook#retrospective)
+
+-- LUNCH --
+
+14.00 - 15.00 - [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning) (for next iteration)

--- a/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
+++ b/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
@@ -1,27 +1,26 @@
 ## Preparing for your build sprint
-1. Depending on whether the results of your user testing have changed your idea significantly, you may need to re-do the following steps:
-  - Break down your user journey into user stories
-  - Draw up your wireframes
-
+1. Break down your user journey into user stories
+1. Re-draw your wireframes (depending on whether the results of your user testing has changed your ideas from the prototype)
 1. Talk through your [choice of tech stack](./tech-choices.md) with the help of your mentors.
-
 1. You may choose to run through the architectural flow of your app at this point.
 
-1. [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning) with your Product Owner and Scrum Master:
-  - Write out your tasks to be done in issues. Start with an issue per user story.
-  - Add:
-    - pictures of your wireframes
-    - acceptance criteria (define these with your PO)
-    - priority labels (immport DWYL labels)
-    - time estimates
-    - Re-order the issues in your milestone accordingly
-    - Assign issues
+## [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning)
 
-    Note: you may want to factor in technical spikes to your build time estimates, depending on your choice of tech stack.
+With your Product Owner and Scrum Master:
+- Write out your tasks to be done in issues. Start with an issue per user story.
+- Add:
+  - pictures of your wireframes
+  - acceptance criteria (define these with your PO)
+  - priority labels (immport DWYL labels)
+  - time estimates
+  - order the issues in your milestone accordingly
+  - assign issues
 
+Note: you may want to factor in technical spikes to your build time estimates, depending on your choice of tech stack.
+
+## Starting work
 1. Write your initial `README.md`
-
-  Remember: You will have a time slot ("Today I Learned" in the 2nd week) for a quick show and tell. If you update your documentation as you go, you can use this to showcase what you have learned to the rest of your cohort.
+Remember: You will have a time slot ("Today I Learned" in the 2nd week) for a quick show and tell. If you update your documentation as you go, you can use this to showcase what you have learned to the rest of your cohort.
 
 1. Set up your environment
   - Deployment (e.g. Heroku)

--- a/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
+++ b/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
@@ -6,24 +6,28 @@
 
 ## [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning)
 
-With your Product Owner and Scrum Master:
-- Write out your tasks to be done in issues. Start with an issue per user story.
-- Add:
-  - pictures of your wireframes
-  - acceptance criteria (define these with your PO)
-  - priority labels (immport DWYL labels)
-  - time estimates
-  - order the issues in your milestone accordingly
-  - assign issues
+With your Product Owner and Scrum Master, write out your tasks to be done in issues.
+
+Start with an issue per user story & break these into sub-issues as/when necessary.
+
+Each issue should contain:
+- pictures of your wireframes
+- acceptance criteria (define these with your PO)
+- a priority label ([import DWYL labels](https://label-sync.herokuapp.com/login))
+- a time estimate
+
+Then
+- order the issues in your milestone accordingly
+- assign issues
 
 Note: you may want to factor in technical spikes to your build time estimates, depending on your choice of tech stack.
 
 ## Starting work
-1. Write your initial `README.md`
+1. Write your initial `README.md`  
 Remember: You will have a time slot ("Today I Learned" in the 2nd week) for a quick show and tell. If you update your documentation as you go, you can use this to showcase what you have learned to the rest of your cohort.
 
 1. Set up your environment
-  - Deployment (e.g. Heroku)
-  - Continuous Integration (e.g. Travis)
-  - Linter
-  - File structure
+    - Deployment (e.g. Heroku)
+    - Continuous Integration (e.g. Travis)
+    - Linter
+    - File structure

--- a/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
+++ b/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
@@ -5,6 +5,8 @@
 
 1. Talk through your [choice of tech stack](./tech-choices.md) with the help of your mentors.
 
+1. You may choose to run through the architectural flow of your app at this point.
+
 1. [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning) with your Product Owner and Scrum Master:
   - Write out your tasks to be done in issues. Add:
     - pictures of your wireframes
@@ -23,3 +25,4 @@
 1. Set up your environment
   - Deployment (e.g. Heroku)
   - Continuous Integration (e.g. Travis)
+  - Linter

--- a/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
+++ b/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
@@ -1,0 +1,25 @@
+## Preparing for your build sprint
+1. Depending on whether the results of your user testing have changed your idea significantly, you may need to re-do the following steps:
+  - Break down your user journey into user stories
+  - Draw up your wireframes
+
+1. Talk through your [choice of tech stack](./tech-choices.md) with the help of your mentors.
+
+1. [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning) with your Product Owner and Scrum Master:
+  - Write out your tasks to be done in issues. Add:
+    - pictures of your wireframes
+    - acceptance criteria (define these with your PO)
+    - priority labels (immport DWYL labels)
+    - time estimates
+    - Re-order the issues in your milestone accordingly
+    - Assign issues
+
+    Note: you may want to factor in technical spikes to your build time estimates, depending on your choice of tech stack.
+
+1. Write your initial `README.md`
+
+  Remember: You will have a time slot ("Today I Learned" in the 2nd week) for a quick show and tell. If you update your documentation as you go, you can use this to showcase what you have learned to the rest of your cohort.
+
+1. Set up your environment
+  - Deployment (e.g. Heroku)
+  - Continuous Integration (e.g. Travis)

--- a/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
+++ b/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
@@ -8,7 +8,8 @@
 1. You may choose to run through the architectural flow of your app at this point.
 
 1. [Sprint planning](https://github.com/dwyl/process-handbook#sprint-planning) with your Product Owner and Scrum Master:
-  - Write out your tasks to be done in issues. Add:
+  - Write out your tasks to be done in issues. Start with an issue per user story.
+  - Add:
     - pictures of your wireframes
     - acceptance criteria (define these with your PO)
     - priority labels (immport DWYL labels)

--- a/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
+++ b/coursebook/weeks-10-12/build-sprint/preparing-for-build-sprint.md
@@ -26,3 +26,4 @@
   - Deployment (e.g. Heroku)
   - Continuous Integration (e.g. Travis)
   - Linter
+  - File structure

--- a/coursebook/weeks-10-12/build-sprint/today-i-learned.md
+++ b/coursebook/weeks-10-12/build-sprint/today-i-learned.md
@@ -1,0 +1,21 @@
+## Today I Learned (TIL)
+
+Popularised by sites like Reddit and Digg:
+> Today I Learned, often shortened as TIL, is an online expression typically used in the title of a post or discussion thread when introducing an interesting fact or trivia that had been previously unknown to the poster, in a similar vein to the phrase “did you know?”
+
+This can be presented as a very short "lightning talk" (10 minutes or less) from your group to the rest of your cohort. So think about what your group has learned that the rest of the cohort would benefit from hearing about.
+
+You can think of this in the same way as the section of your [presentations during weeks 1-8](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/weekly-projects.md#project-presentation) where you discuss "something you're proud of" and/or "something that you found really hard / struggled with".
+
+Your TIL can be on any topic that has been relevant to your team.
+
+It could be something broad:
++ implementation of Agile roles
++ division of tasks
++ workflow
++ pivotting from one idea to another
++ how to conduct a spike effectively (e.g. on a new technology)
+
+or you may want to "deep dive" into a specific piece of code, in order to demonstrate:
++ a new piece of tech
++ deeper understanding & consolidation of a topic from weeks 1-8


### PR DESCRIPTION
Schedule timings for the following:
#### Specific to build sprint
+ Talk on workflow #581 
+ create clearer timings for user testing on penultimate day
+ Agile ceremonies #582 
+ "Today I Learned" (end of first week of build sprint) #614 
+ Add creation of case studies #613 

#### Generic FAC curriculum time slots
+ Introduce the week(s) i.e. learning outcomes & schedule (first 15 mins of day 1)
+ Business development
+ Curriculum planning / mentor preparation
+ Day 3 & 5 speaker slots
+ Weekly SGC

#615 