### PR TITLE
Migrate first FCI standup minutes

### DIFF
--- a/facilitation/2017-06-16-B.md
+++ b/facilitation/2017-06-16-B.md
@@ -1,0 +1,158 @@
+# Minutes from first meeting (16/06/2017)
+
+**Facilitator:** @rebeccaradding
+
+**Time Keeper:**
+
+**Mood Monitor:**
+
+**Record Keeper:** @jsms90 (from 2nd proposal)
+
+**Vote Taker:** @jsms90
+
+## Attendance and voting
+MG, Eoin, Bradley, Jen, Elias, Rebecca, Dan
+
+https://docs.google.com/spreadsheets/d/1vJ_rDHnoRq1Q5BewbucGxU7iD058PsOoY1hGajO-EIY/edit#gid=0
+
+---
+
+## Agenda
+
+1. [Proposal: Making decisions that affect all campuses](#proposal-making-decisions-that-affect-all-campuses)
+2. [Proposal: FCI + Course Facilitator Communication](#proposal-fci--course-facilitator-communication)
+3. [Role: Course Facilitator](#role-course-facilitator)
+
+---
+
+## [Proposal: Making decisions that affect all campuses](https://github.com/foundersandcoders/international/issues/59)
+
++ **Clarification from @sofer:** anyone who has facilitated for at least two months can count toward the quorum.
+
++ **Clarification from @des-des:** (non-facilitators) can co-sponsor proposals and attend meetings where their proposals are being decided.
+
++ **Question from @mantagen:** what about campuses making decisions that contradict decisions made by the FCI team?
+
++ **Question from @mantagen:** what about the campus who isn't represented in the case of a quorum?
+
++ **Question from @des-des:** is this an executive decision-making body for FCI? How does this affect the charity status of FAC International and the proposal for how it will make decisions?  
+  + @sofer: this proposed committee has delegated decision making power. The trustees and/or membership can withdraw that power if they feel it is being misused.  
+
+  + @des-des: we need more clarification on what this committee is responsible for. Let's add clarity around responsibilities - fundamental changes to the Founders & Coders course (including onramp and offramp) that affect all campuses:
+    + Application/selection
+    + Curriculum planning
+    + Maintenance and practice of `master-reference`
+
++ **@bradreeder:** How does a course facilitator ensure that they are representing their campus? Is it necessary for them to share it with the broader community before the meeting?
+
++ **@jsms90:** wants quorum to include one representative from each campus, 2/3 from FCI.
+
+All agree to modify proposal!
+
++ **Question from @jsms90:** how much autonomy does a campus have? However much it needs - divergence should just be documented at the international level.
+
+**Status:**  
+Passed 7/7
+
+## [Proposal: FCI + Course Facilitator Communication](https://github.com/foundersandcoders/international/issues/58)
+
+MG:
++ What is meant by "sets goals"?
+
+Rebecca:
++ Goals related to description of course facilitator. Any area where seeks growth or wants feedback. Just based on role of facilitator, or sounding board.
+
+Eoin:
++ Sounds very top-down
+
+Rebecca:
++ Written "with" on purpose
+
+Eoin:
++ Swap order? i.e. course facilitator sets goals _with_ international staff
+
+MG:
++ Are those goals set in weekly 30 minute mentorship meeting.
+
+Rebecca:
++ Yes.
+
+Eoin:
++ So 2 hours a week for you guys. 1 hour a week for the course facilitators.
+
+Rebecca & Dan:
++ Yes.
+
+Jen:
++ Add post-course meeting between FCI + course facilitators to the "What"?
+
+Eoin:
++ Should be on a different proposal
+
+Rebecca:
++ You should join stand-up once you're a facilitator
+
+Eoin:
++ If you want to join, you could sit in on the meeting.
+
+Rebecca:
++ I would encourage that. You should definitely be on the call the week before you take over.
+
+**Status:**  
+Passed 7/7
+
+**Action point:**
++ Raise new proposal about pre-course, post-course & reading week meetings
+
+## [Role: Course Facilitator](https://github.com/foundersandcoders/international/issues/57)
+
+Rebecca:
++ Should have raised as a proposal. Maybe I could have. Feels like something that International should have defined already.
+
+Eoin:
++ Might be detrimental to someone's mental health to suggest that this is a 20 hour week role. What if it takes someone longer?
+
+Bradley:
++ Don't believe it's part-time.
++ For transparency, I'm taking a break from facilitating for the first month because I know the realistically the workload is heavier than what is described, and I . I know that Jen will be doing more than the 20 hours described here.
++ Because there is only one person being paid to do stuff right now, unless they do everything, it doesn't get done. So really, it still falls on them anyway. It would only take a few more things added to the list to make it obviously full time.
++ I'm concerned and I agree with Eoin that it puts a lot of undue stress on people. Especially taking other part-time roles to sustain yourself, it can have an effect on someone's mental health.
+
+Rebecca:
++ This is a new formulation of the role, with more support. We just don't know right now, how much time it will take.
++ We don't have enough data. I would love us to be able to base this on something more substantial, so that we're setting realistic expectations. It needs to be based on the experiences of more people, in more locations.
+
+Jen:
++ Just want to reiterate - not a part time role.
++ Understand why you're saying what you're saying, and get that you don't feel like you have evidence.
++ Happy for this to go through for now, but I just want my objection noted.
++ I didn't track it to the exact hour, but I've outlined roughly which hours of the day and which days of the week I was working. I was doing over 20 hours a week for FAC10 and it absolutely wasn't enough. Only gave that little because it was all the time I had.
+
+Rebecca:
++ No support before. Stand-ups may help to lighten the load. Might mention something that's lacking e.g. documentation, and someone from International could pick it up.
++ May be that some of that happens. May be that some of it won't. We don't know yet.
+
+Jen:
++ Even with more support, that only lightens one part of the load. It's still just not possible in 20 hours. It's not a part-time job, if you're doing it well.
+
+Dan:
++ All bounded by what resources we have and our financial constraints. By passing our proposal, we're making some very weak assumptions and I expect it to change significantly over the course of the month.
+
+Eoin:
++ Add another caveat? Sorry, really re-writing your proposal. Make expectations really clear about what's _expected_ and what might not get done.
+
+Rebecca:
++ Within the time they have available, course facilitators will attempt the following tasks? They should also communicate tasks that haven't been completed to FCI so that we can problem-solve around reassignment.
++ We're happy to revisit this, knowing that these are our resources constraints and financial constraints at the moment.
+
+Eoin:
++ Specify "per calendar month" on the payment?
+
+Dan:
++ Clarifying - £60 per day.
++ We've somewhat arbitrarily split the role in Gaza/Nazareth down the middle between graduate project QA-ing and facilitation. The Gaza course facilitators will be doing both.
+
+**Action points:**
++ Everyone track their hours
++ FCI revisit in 2 months
++ Set weekly times for stand-ups


### PR DESCRIPTION
Moves June minutes from `international`; seems to think this file already exists (but I can't find it) so I added a "B" for now.