### PR TITLE
correct mistake in week2 project skeleton

### DIFF
--- a/coursebook/week-2/project/skeleton/logic.js
+++ b/coursebook/week-2/project/skeleton/logic.js
@@ -19,7 +19,7 @@ var todoFunctions = {
   //changes to the new array don't affect the original
   cloneArrayOfObjects: function(todos) {
     return todos.map(function(todo){
-      return JSON.parse(JSON.stringify(object));
+      return JSON.parse(JSON.stringify(todo));
     });
   },
   


### PR DESCRIPTION
Oops - the JSON stringify function in the new helper function was called on 'object', which wasn't defined. The current cohort now know and have updated their code. Can we get this merged and fixed for the other campuses?

Thanks