### PR TITLE
Remove Google Cast from list of extensions

### DIFF
--- a/coursebook/precourse/README.md
+++ b/coursebook/precourse/README.md
@@ -133,5 +133,4 @@ Note: We will be covering Node.js during the course. If you are curious and woul
   - color-picker
 - Chrome extensions:
   - JSONView
-  - Google Cast
   - Postman


### PR DESCRIPTION
This is now built into Chrome 

https://support.google.com/chromecast/answer/6398952?hl=en-GB