### PR TITLE
Separate handlebars from express

### DIFF
--- a/coursebook/week-8/README.md
+++ b/coursebook/week-8/README.md
@@ -13,7 +13,7 @@ Schedule
 
 --LUNCH--
 
-14:00-16:00 - Workshop 2 - [Handlebars](https://github.com/foundersandcoders/express-handlebars-workshop)
+14:00-16:00 - Workshop 2 - [Creating and Testing Express Routes](https://github.com/foundersandcoders/express-and-testing-workshop)
 
 16:00-18:00 - Business Development / Community Engagement
 
@@ -22,7 +22,7 @@ Schedule
 10:00-11:00 - Morning Challenge - [Create an Animated App
 Drawer](https://github.com/foundersandcoders/morning-challenge-animated-app-drawer)
 
-11:00-12:45 - Workshop 3 - [Creating and Testing Express Routes](https://github.com/foundersandcoders/express-and-testing-workshop)
+11:00-12:45 - Workshop 3 - [Handlebars](https://github.com/foundersandcoders/express-handlebars-workshop)
 
 12:45-13:00 - Introduce research topics, assign names on whiteboard and jigsaw
 teams.

--- a/coursebook/week-8/README.md
+++ b/coursebook/week-8/README.md
@@ -22,7 +22,7 @@ Schedule
 10:00-11:00 - Morning Challenge - [Create an Animated App
 Drawer](https://github.com/foundersandcoders/morning-challenge-animated-app-drawer)
 
-11:00-13:00 - Workshop 3 - [Creating and Testing Express Routes](https://github.com/foundersandcoders/express-and-testing-workshop)
+11:00-13:00 - Workshop 3 - [Handlebars](https://github.com/foundersandcoders/express-handlebars-workshop)
 
 
 --LUNCH--


### PR DESCRIPTION
close #837 
Following the Week 8 suggestion - Gaza mentors #797 to
Separate handlebars from express.
the changes will be created.

**The suggestion is** : 
Split the content of Day-1 between Day 1 and 2 as 

- **Day 1:** introduce the express, express workshop and testing workshop (Creating and Testing Express Routes)
- **Day 2:** Create an Animated App Drawer morning challenge, introduce handlebars followed by the afternoon research 