### PR TITLE
fix links to renamed workshop

### DIFF
--- a/coursebook/week-7/README.md
+++ b/coursebook/week-7/README.md
@@ -4,40 +4,36 @@
 
 - 10:00 - 10:15 - Introduction to [learning outcomes](./learning-outcomes.md)
 
-- 10:15 - 11:00 - Presentation on [Password Management](https://drive.google.com/file/d/0BxXF_LZcFnS5ODM0dElWYmtmMWc/view)
+- 10:15 - 11:00 - Presentation on [password management](https://drive.google.com/file/d/0BxXF_LZcFnS5ODM0dElWYmtmMWc/view)
 
-- 11:00 - 13:00 - Workshop on [Password Management](https://github.com/foundersandcoders/ws-password-management)
+- 11:00 - 13:00 - Workshop on [password management](https://github.com/foundersandcoders/ws-password-management)
 
 — LUNCH —
 
-- 14:00 - 16:00 - Workshop on [Cookies](https://github.com/foundersandcoders/ws-cookies)
+- 14:00 - 16:00 - Workshop on [cookies](https://github.com/foundersandcoders/ws-cookies)
 
 - 16:00 - 18:00 - Business development
 
 #### Day 2
 
-- 10:00-11:00 - Morning Challenge on [Client Side Validation](https://github.com/foundersandcoders/mc-client-side-validation)
+- 10:00-11:00 - Morning Challenge on [client side validation](https://github.com/foundersandcoders/mc-client-side-validation)
 
-- 11:00-13:00 - Workshop on [Session Management](https://github.com/foundersandcoders/ws-session-management)
+- 11:00-13:00 - Workshop on [stateless session management](https://github.com/foundersandcoders/ws-jwt-stateless-session)
 
 
 — LUNCH —
 
-- 14:00 - 14:30
--- [Introduce Project](./project.md)
+- 14:00 - 14:30 - [Introduce project](./project.md)
 
-- 14:30 - 14:45
--- Introduce [research topics](./research-afternoon.md)
+- 14:30 - 14:45 - Introduce [research topics](./research-afternoon.md)
 
-- 14.45 - 17:00
--- [Research Afternoon](./research-afternoon.md)
+- 14.45 - 17:00 - [Research afternoon](./research-afternoon.md)
 
-- 17.00 - 18:00
--- Review and Present research topics
+- 17.00 - 18:00 - Review and Present research topics
 
 #### Day 3
 
-- 10:00 - 11:00 - Morning Challenge on [Promises](https://github.com/foundersandcoders/mc-promise-me-this)
+- 10:00 - 11:00 - Morning challenge on [Promises](https://github.com/foundersandcoders/mc-promise-me-this)
 
 - 11:00 - 13:00 - Projects (planning)
 
@@ -45,7 +41,7 @@
 
 - 14:00 - 17:00 - Projects
 
-- 17:00 - 18:00 - External Speaker or Alumni Project Presentation
+- 17:00 - 18:00 - External speaker or alumni project presentation
 
 #### Day 4
 
@@ -71,4 +67,4 @@
 
 - 15:40-17:00 - Presentations (20 mins per group)
 
-- 17:00-18:00 - External Speaker or Alumni Project Presentation
+- 17:00-18:00 - External speaker or alumni project presentation

--- a/curriculum-planning/resource-index.md
+++ b/curriculum-planning/resource-index.md
@@ -2,7 +2,7 @@
 
 * [Software Design](https://github.com/foundersandcoders/ws-software-design-js)
 * [Password Management](https://github.com/foundersandcoders/ws-password-management)
-* [Session Management](https://github.com/foundersandcoders/ws-session-management)
+* [JWT Stateless Session Management](https://github.com/foundersandcoders/ws-jwt-stateless-session)
 * [Cookies](https://github.com/foundersandcoders/ws-cookies)
 * [Webpack Bundling](https://github.com/foundersandcoders/ws-webpack-bundling)
 * [hapi-auth-cookie](https://github.com/foundersandcoders/hapi-auth-cookie-ws)


### PR DESCRIPTION
related to #828

Renamed `ws-session-management` to `ws-jwt-stateless-session`