### PR TITLE
fix DOM manip link and add more resources > relates #810

### DIFF
--- a/coursebook/precourse/README.md
+++ b/coursebook/precourse/README.md
@@ -74,9 +74,13 @@ _Learning outcomes:_
 - Understand what the DOM is
 - Create, access, and style a DOM element
 
-_Resourcs:_  
-+ [Call Me Nick - DOM Manipulation Basics](http://callmenick.com/post/basics-javascript-dom-manipulation) will cover a lot of the basics.
+_Resources:_  
++ [Call Me Nick - DOM Manipulation Basics](https://web.archive.org/web/20170718105716/https://callmenick.com/post/basics-javascript-dom-manipulation) (archived version) will cover a lot of the basics.
++ [MDN article on "Manipulating Documents"](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Manipulating_documents) - useful for some further reading, if you'd like
 + [Appspot's DOM Tutorials: Exercises 1,2 & 3 only](https://dom-tutorials.appspot.com/static/index.html) will help put that into practice.
++ Bonus videos:
+  + [The DOM: What is the Document Object Model?](https://www.youtube.com/watch?v=80Mr2Z6Qikc) (includes some jQuery, but provides a useful overview and some vanilla JS examples)
+  + [Live coding intro to the DOM, with JS examples](https://www.youtube.com/watch?v=eaLKqoB9Fu0)
 
 ### Practical Project
 


### PR DESCRIPTION
Changed the "Call me Nick" link to point to the archived page, and added more links suggested by matjack1 in issue #810 . Noted that they're "bonus"/optional to try to avoid increasing pre-course load much.