### PR TITLE
New Schedule, Possibly WIP

### DIFF
--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -7,71 +7,42 @@
 - [Project](./project.md)
 - [Resources](./resources.md)
 
-## Day 1
+## Schedule
 
-- 10.00 - 10.30 — [Welcome talk](https://github.com/foundersandcoders/master-reference/blob/master/about.md)
-- 10:30 - 11:30 — Name game with as many members of Founders and Coders as possible!
-- 11:30 - 11:40 - Toilet/Coffee Break
-- 11:40 - 13:00 - Course overview
-  - Go through 16 week [schedule](https://github.com/foundersandcoders/master-reference/tree/master/coursebook)
-  - [Code of Conduct](https://github.com/foundersandcoders/master-reference/blob/master/code-of-conduct.md)
-  - [House rules](../general/house-rules.md)
-  - Campus-specific info
-  - Introduce gitter channels
+Day 1|Day 2|Day 3|Day 4| Day 5 
+---|---|---|---|---
+Welcome fun ~**2hr** |Accessibility Morning Challenge ~**1hr**|CSS Morning Challenge ~**1hr**| Projects| Code review (with how to) ~**1hr**
+Intro To PP ~**1hr**|Github Workshop ~**2hr**|Projects (all day!)|| Respond to issues ~**2hr**
+Accessibility WS ~**1hr**|Introduce Project and research ~**1hr**| Community Talk ~**1hr**||Presentation planning ~**1hr**
+Github Hunt ~**1hr**|Research + Presentations ~**3hr**||| Presentations ~**1hr**
+Intro to communal Decision making ~**1hr**||||Stop Go Continues! ~**2hr**
 
-— LUNCH —
+### Links:
 
-- 14:00 - 14:50 — Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/pair-programming.md)
-- 14:50 - 15:00 — Toilet/Coffee Break
-- 15:00 - 16:00 — [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility/blob/master/putting-yourself-in-someone-elses-shoes.md)
-- 16.00 - 17.00 — [Github Scavenger Hunt - master reference](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/github-scavenger-hunt.md)  
-  Github Scavenger Hunt - campus specific  
-  [London](https://github.com/foundersandcoders/london-programme/blob/master/github-scavenger-hunt.md)  
-  [Nazareth](https://github.com/foundersandcoders/nazareth-programme/blob/master/github-scavenger-hunt.md)
-- 17:00 - 18:00 — Introduction to consensus based decision-making
+#### Day 1
+- [Welcome talk](https://github.com/foundersandcoders/master-reference/blob/master/about.md)
+- [Schedule](https://github.com/foundersandcoders/master-reference/tree/master/coursebook)
+- [Code of Conduct](https://github.com/foundersandcoders/master-reference/blob/master/code-of-conduct.md)
+- [House rules](../general/house-rules.md)
 
-## Day 2
+- [Introduction to Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/pair-programming.md)
+- [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility/blob/master/putting-yourself-in-someone-elses-shoes.md)
+- [Github Scavenger Hunt - master reference](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/github-scavenger-hunt.md)  
+#### Day 2
+- [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge)
+- [Git workshop](https://github.com/foundersandcoders/git-workflow-workshop-for-two)
+- [Introduce Project](./project.md)
+- [Introduce Research topics](./research-afternoon.md)
+- [Presentation Guidance](./presentation-guidance.md)
 
-- 10:00 - 11:00 — Morning Challenge - [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge)
-- 11:00 - 13:00 — [Git workshop](https://github.com/foundersandcoders/git-workflow-workshop-for-two)
+#### Day 3
 
-— LUNCH —
+- [Morning Challenge - CSS Gallery Challenge](https://github.com/foundersandcoders/css-gallery-challenge)
+- [FAC Community talk](https://docs.google.com/presentation/d/1p-45WEiZ6QHacF9L-Xt1JwEpUrwgxHvLlgL5F-sw9os/edit?usp=sharing)
 
-- 14:00 - 14:30 — Introduce [Project](./project.md)
-- 14:30 - 14:45 — Introduce [Research topics](./research-afternoon.md)
-- 14:45 - 15:00 — [Presentation Guidance](./presentation-guidance.md)
-- 15:00 - 17:00 — Research / TBC
-- 17.00 - 18:00 — Research presentations
+#### Day 5
 
-## Day 3
-
-- 10.00 - 11.00 — [Morning Challenge - CSS Gallery Challenge](https://github.com/foundersandcoders/css-gallery-challenge)
-- 11.00 - 13.00 — Projects
-
-— LUNCH —
-
-- 14.00 - 17.30 — Projects
-- 17.30 - 18.00 — [FAC Community talk](https://docs.google.com/presentation/d/1p-45WEiZ6QHacF9L-Xt1JwEpUrwgxHvLlgL5F-sw9os/edit?usp=sharing)
-
-## Day 4
-
-- 10.00 - 13.00 — Projects
-
-— LUNCH —
-
-- 14.00 - 18.00 — Projects
-
-## Day 5
-
-- 10:00 - 10:15 - How to Code review [here](./codereviewintro.md)
-- 10.15 - 11.00 — Code review (1 alumnus per project, 1 team reviews another team)
-- 11.00 - 13:00 — Respond to issues
-
-— LUNCH —
-
-- 14:00 - 14.15 — [Plan presentations](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/weekly-projects.md#project-presentation)
-- 14:15 - 15:35 - Presentations (20 mins per group)
-- 15:35 - 15:45 - Toilet/Coffee Break
-- 15:45 - 16:45 -[Cohort Stop Go Continue (retrospective)](./retrospectives.md#cohort-retrospective)
-- 16:45 - 17:00 - [Team retrospectives](./retrospectives.md#team-retrospective)
-- 17:00 - 18:00 - External Speaker or Alumni Project Presentation
+- [How to Code review](./codereviewintro.md)
+- [Plan presentations](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/weekly-projects.md#project-presentation)
+- [Cohort Stop Go Continue (retrospective)](./retrospectives.md#cohort-retrospective)
+- [Team retrospectives](./retrospectives.md#team-retrospective)


### PR DESCRIPTION
Hey so this is something I've been thinking about for a while, how the readme's for each week are a bit overly specific (scheduling toilet breaks!) and not necessarily universal across campus (with timings and such), and also quite hard to read at a glance.

This isn't necessarily the solution but I definitely think it's an improvement and it's probably something I would do for the rest of the weeks if you guys agree.

@eliascodes and @shiryz this could also fold into the long term idea of having a schedule with guidance on when to teach things and with links for those things below?

n.b.
- I have removed the campus specific links for scavenger hunt as I think they can just be linked by the CF at the time and it's not scalable to have them all here all the time?
- I've merged the introduction specificity just into "Welcome fun" - I guess _might_ need notes to explain exactly what that means but from my experience the first day often changes cohort to cohort and campus to campus