### PR TITLE
Update tfb process

### DIFF
--- a/coursebook/week-2/README.md
+++ b/coursebook/week-2/README.md
@@ -26,7 +26,8 @@
   Roman numerals TDD code-along - [final solution](https://github.com/foundersandcoders/roman-numeral-tdd-codealong)
 
 - 16:00 - 18:00 <br>
-  Business development / community engagement
+  - Business Development / Community Engagement
+  - Tech for Better Discovery workshop run-through: [slides here](https://facresources.com/slides/tfb-discovery-workshop.html#/)
 
 ### Day 2
 

--- a/coursebook/week-3/README.md
+++ b/coursebook/week-3/README.md
@@ -18,9 +18,9 @@
 
 -- LUNCHTIME 😋 --
 
-- 14.00 - 16.00 <br /> [Afternoon workshop](https://github.com/emilyb7/workshop-APIs) : making API requests in the browser, callbacks, working with JSON, chaining API requests
-
-- 16.00 - 18.00 <br /> Biz Dev / Community Engagement
+- 16:00 - 18:00 <br>
+  - Business Development / Community Engagement
+  - Tech for Better Discovery workshop: [slides here](https://facresources.com/slides/tfb-discovery-workshop.html#/)
 
 ### Day 2
 

--- a/coursebook/week-3/README.md
+++ b/coursebook/week-3/README.md
@@ -18,6 +18,8 @@
 
 -- LUNCHTIME 😋 --
 
+- 14.00 - 16.00 <br /> [Afternoon workshop](https://github.com/emilyb7/workshop-APIs) : making API requests in the browser, callbacks, working with JSON, chaining API requests
+
 - 16:00 - 18:00 <br>
   - Business Development / Community Engagement
   - Tech for Better Discovery workshop: [slides here](https://facresources.com/slides/tfb-discovery-workshop.html#/)

--- a/coursebook/week-3/README.md
+++ b/coursebook/week-3/README.md
@@ -51,6 +51,8 @@
 
 ### Day 4
 
+- 10.00 - 10.20 <br /> (Tech for Better Discovery workshop reflection)
+
 - 10.00 - 13.00 <br /> Projects
 
 -- LUNCHTIME 😋 --

--- a/coursebook/week-4/README.md
+++ b/coursebook/week-4/README.md
@@ -17,8 +17,10 @@
 
 - 14:00 - 16:00
   -- [Node Girls workshop](https://github.com/node-girls/workshop-cms) (Day 1 of 2)
-- 16:00 - 18:00
-  -- Business development
+
+- 16:00 - 18:00 <br>
+    - Business Development / Community Engagement
+    - Tech for Better Discovery workshop: [slides here](https://facresources.com/slides/tfb-discovery-workshop.html#/)
 
 ### Day 2
 

--- a/coursebook/week-4/README.md
+++ b/coursebook/week-4/README.md
@@ -62,6 +62,8 @@
 
 ### Day 4
 
+- 10.00 - 10.20 — (Tech for Better Discovery workshop reflection)
+
 - 10:00 - 18:00
   -- Projects
 

--- a/coursebook/week-5/README.md
+++ b/coursebook/week-5/README.md
@@ -19,7 +19,9 @@
 
 - 14:00 - 16:00 - [Workshop on error handling](https://github.com/foundersandcoders/error-handling-workshop)
 
-- 16:00 - 18:00 - Business development
+- 16:00 - 18:00 <br>
+  - Business Development / Community Engagement
+  - Tech for Better Discovery workshop: [slides here](https://facresources.com/slides/tfb-discovery-workshop.html#/)
 
 ### Day 2
 

--- a/coursebook/week-5/README.md
+++ b/coursebook/week-5/README.md
@@ -57,6 +57,8 @@
 
 ### Day 4
 
+ - 10.00 - 10.20 - (Tech for Better Discovery workshop reflection)
+
 - 10:00 - 13:00 - Projects
 
 — LUNCH —

--- a/coursebook/week-6/README.md
+++ b/coursebook/week-6/README.md
@@ -56,7 +56,9 @@ Then go to [`sql-commands-intro` workshop](https://github.com/foundersandcoders/
 
 ### Day 4
 
-Continue work on projects
+- 10.00 - 10.20 <br /> (Tech for Better Discovery workshop reflection)
+
+- 10.00 - 18.00 <br /> Projects
 
 ### Day 5
 

--- a/coursebook/week-6/README.md
+++ b/coursebook/week-6/README.md
@@ -21,7 +21,9 @@ Then go to [`sql-commands-intro` workshop](https://github.com/foundersandcoders/
 
 2pm - 4.00pm: [workshop on SQL commands and psql](https://github.com/foundersandcoders/postgres-workshop).
 
-4.00pm - 6pm: biz dev and community outreach
+4pm - 6pm: <br>
+  - Business Development / Community Engagement
+  - Tech for Better Discovery workshop: [slides here](https://facresources.com/slides/tfb-discovery-workshop.html#/)
 
 ### Day 2
 

--- a/coursebook/week-7/README.md
+++ b/coursebook/week-7/README.md
@@ -20,7 +20,9 @@
 
 - 14:00 - 16:00 - Workshop on [cookies](https://github.com/foundersandcoders/ws-cookies)
 
-- 16:00 - 18:00 - Business development
+- 16:00 - 18:00 <br>
+  - Business Development / Community Engagement
+  - Tech for Better Discovery workshop: [slides here](https://facresources.com/slides/tfb-discovery-workshop.html#/)
 
 ### Day 2
 

--- a/coursebook/week-7/README.md
+++ b/coursebook/week-7/README.md
@@ -54,6 +54,8 @@
 
 ### Day 4
 
+- 10.00 - 10.20 - (Tech for Better Discovery workshop reflection)
+
 - 10:00 - 13:00 - Projects
 
 — LUNCH —

--- a/coursebook/week-8/README.md
+++ b/coursebook/week-8/README.md
@@ -21,7 +21,9 @@
 
 14:00-16:00 - Workshop 2 - [Creating and Testing Express Routes](https://github.com/foundersandcoders/express-and-testing-workshop)
 
-16:00-18:00 - Business Development / Community Engagement
+16:00 - 18:00 <br>
+  - Business Development / Community Engagement
+  - Tech for Better Discovery workshop: [slides here](https://facresources.com/slides/tfb-discovery-workshop.html#/)
 
 ### Day 2
 

--- a/coursebook/week-8/README.md
+++ b/coursebook/week-8/README.md
@@ -60,6 +60,8 @@ Drawer](https://github.com/foundersandcoders/morning-challenge-animated-app-draw
 
 ### Day 4
 
+10.00 - 10.20 - (Tech for Better Discovery workshop reflection)
+
 10:00-13:00 - Group Project
 
 --LUNCH--


### PR DESCRIPTION
- Added a link to the slides for the Tech for Better discovery workshop in the 16:00-18:00 slot, Day 1 on the relevant weeks

- Added an (optional) 20-minute space at the beginning of Day 4 on the relevant.

This latter point arose from a discussion with @sofer - at the moment, students are slow to update the issues in `tech-for-better-leads` with feedback and their notes from the discovery workshops. We thought a scheduled, short session on the morning of Day 4, where the students have to quickly sum up the project/organisation they worked with to the rest of the class, would help to get the issues filled out earlier. It'd also be an opportunity for those who worked with a PO to give their honest opinion on the project that came through the door, and for those who didn't work on that project to get a better understanding (before they have to pick!).

The proposed external link in Day 1 to facresources.com, as well as the lack of documentation on the TFB workshops, makes me think this could be part of a move towards **a bit more documentation** on **how the TFB process works for students**, as well as instructions on how to carry out the workshops. 

Perhaps it could take the shape of its own `tech-for-better` folder in the master ref, which would contain links to the relevant workshops, how to run them, as well as an overview of the process through the course for the students. Or is this all too London-specific?