### PR TITLE
Change/week1

### DIFF
--- a/coursebook/general/user-manuals.md
+++ b/coursebook/general/user-manuals.md
@@ -1,0 +1,3 @@
+# User manuals
+
+[in progress]

--- a/coursebook/schedules/default.md
+++ b/coursebook/schedules/default.md
@@ -18,3 +18,6 @@ Hour | Day 1 | Day 2 | Day 3 | Day 4 | Day 5
 6h | Workshops | Presentations | Talk | Projects | Talk
   |   |   |   |   |  
 7h | Class ends |   |   |   |  
+
+
+### [London default schedule](./london-default.md)

--- a/coursebook/schedules/default.md
+++ b/coursebook/schedules/default.md
@@ -1,23 +1,23 @@
 # Default schedule for Weeks 1-8
 
-Hour | Day 1 | Day 2 | Day 3 | Day 4 | Day 5
--- | -- | -- | -- | -- | --
-  |   |   |   |   |  
-0h | Workshops | Challenge | Challenge | Projects | Code review
-  |   |   |   |   |  
-1h | Workshops | Workshops | Projects | Projects | Review issues
-  |   |   |   |   |  
-2h | Workshops | Workshops | Projects | Projects | Prepare presentations
-  |   |   |   |   |  
-3h | Workshops | Project intro | [Design burst](https://github.com/foundersandcoders/design-bursts) | Projects | Presentations
-  |   | Research intro | Projects |   |  
-4h | Workshops | Research | Projects | Projects | Presentations
-  |   |   |   |   | SGC
-5h | Workshops | Prepare presentations | Projects | Projects | SGC
-  |   |   |   |   | Team retrospectives
-6h | Workshops | Presentations | Talk | Projects | Talk
-  |   |   |   |   |  
-7h | Class ends |   |   |   |  
+|Hour| Day 1     | Day 2                | Day 3                                          | Day 4    | Day 5                 |
+|----| ----------| ---------------------| -----------------------------------------------| -------- | --------------------- |
+|    |           |                      |                                                |          |                       |
+|0h  | Workshops | Challenge            | Challenge                                      | Projects | Code review           |
+|    |           |                      |                                                |          |                       |
+|1h  | Workshops | Workshops            | Projects                                       | Projects | Review issues         |
+|    |           |                      |                                                |          |                       |
+|2h  | Workshops | Workshops            | Projects                                       | Projects | Prepare presentations |
+|    |           |                      |                                                |          |                       |
+|3h  | Workshops | Project intro        | [Design burst](../../../../../../design-bursts)| Projects | Presentations         |
+|    |           | Research intro       | Projects                                       |          |                       |
+|4h  | Workshops | Research             | Projects                                       | Projects | Presentations         |
+|    |           |                      |                                                |          | SGC                   |
+|5h  | Workshops | Prepare presentations| Projects                                       | Projects | SGC                   |
+|    |           |                      |                                                |          | Team retrospectives   |
+|6h  | Workshops | Presentations        | Talk                                           | Projects | Talk                  |
+|    |           |                      |                                                |          |                       |
+|7h  | Class ends|                      |                                                |          |                       |
 
 
 ### [London default schedule](./london-default.md)

--- a/coursebook/schedules/default.md
+++ b/coursebook/schedules/default.md
@@ -9,7 +9,7 @@ Hour | Day 1 | Day 2 | Day 3 | Day 4 | Day 5
   |   |   |   |   |  
 2h | Workshops | Workshops | Projects | Projects | Prepare presentations
   |   |   |   |   |  
-3h | Workshops | Project intro | Design burst | Projects | Presentations
+3h | Workshops | Project intro | [Design burst](https://github.com/foundersandcoders/design-bursts) | Projects | Presentations
   |   | Research intro | Projects |   |  
 4h | Workshops | Research | Projects | Projects | Presentations
   |   |   |   |   | SGC

--- a/coursebook/schedules/london-default.md
+++ b/coursebook/schedules/london-default.md
@@ -1,21 +1,21 @@
 # London Programme default schedule, Weeks 1-8
 
-Start time | Day 1 | Day 2 | Day 3 | Day 4 | Day 5
--- | -- | -- | -- | -- | --
-  |   |   |   |   |  
-10am | Workshops | Challenge | Challenge | Projects | Code review
-  |   |   |   |   |  
-11am | Workshops | Workshops | Projects | Projects | Review issues
-  |   |   |   |   |  
-12pm | Workshops | Workshops | Projects | Projects | Prepare presentations
-  |   |   |   |   |  
-1pm | Lunch | Lunch | Lunch | Lunch | Lunch
-  |   |   |   |   |  
-2pm | Workshops | Project intro | [Design burst](https://github.com/foundersandcoders/design-bursts) | Projects | Presentations
-  |   | Research intro | Projects |   |  
-3pm | Workshops | Research | Projects | Projects | Presentations
-  |   |   |   |   | SGC
-4pm | Workshops | Prepare presentations | Projects | Projects | SGC
-  |   |   |   |   | Team retrospectives
-5pm | Workshops | Presentations | Talk | Projects | Talk
-  |   |   |   |   |  
+|Start| Day 1    | Day 2                | Day 3                                          | Day 4    | Day 5                 |
+|-----| ---------| ---------------------| -----------------------------------------------| -------- | --------------------- |
+|     |          |                      |                                                |          |                       |
+|10am | Workshops| Challenge            | Challenge                                      | Projects | Code review           |
+|     |          |                      |                                                |          |                       |
+|11am | Workshops| Workshops            | Projects                                       | Projects | Review issues         |
+|     |          |                      |                                                |          |                       |
+|12pm | Workshops| Workshops            | Projects                                       | Projects | Prepare presentations |
+|     |          |                      |                                                |          |                       |
+|1pm  | Lunch    | Lunch                | Lunch                                          | Lunch    | Lunch                 |
+|     |          |                      |                                                |          |                       |
+|2pm  | Workshops| Project intro        | [Design burst](../../../../../../design-bursts)| Projects | Presentations         |
+|     |          | Research intro       | Projects                                       |          |                       |
+|3pm  | Workshops| Research             | Projects                                       | Projects | Presentations         |
+|     |          |                      |                                                |          | SGC                   |
+|4pm  | Workshops| Prepare presentations| Projects                                       | Projects | SGC                   |
+|     |          |                      |                                                |          | Team retrospectives   |
+|5pm  | Workshops| Presentations        | Talk                                           | Projects | Talk                  |
+|     |          |                      |                                                |          |                       | 

--- a/coursebook/schedules/london-default.md
+++ b/coursebook/schedules/london-default.md
@@ -3,8 +3,8 @@
 |Start| Day 1    | Day 2                | Day 3                                          | Day 4    | Day 5                 |
 |-----| ---------| ---------------------| -----------------------------------------------| -------- | --------------------- |
 |     |          |                      |                                                |          |                       |
-|10am | Workshops| Challenge            | Challenge                                      | Projects | Code review           |
-|     |          |                      |                                                |          |                       |
+|10am | Intro    | Challenge            | Challenge                                      | Projects | Code review           |
+|     | Workshops|                      |                                                |          |                       |
 |11am | Workshops| Workshops            | Projects                                       | Projects | Review issues         |
 |     |          |                      |                                                |          |                       |
 |12pm | Workshops| Workshops            | Projects                                       | Projects | Prepare presentations |
@@ -15,7 +15,8 @@
 |     |          | Research intro       | Projects                                       |          |                       |
 |3pm  | Workshops| Research             | Projects                                       | Projects | Presentations         |
 |     |          |                      |                                                |          | SGC                   |
-|4pm  | Workshops| Prepare presentations| Projects                                       | Projects | SGC                   |
+|4pm  | Tech for | Prepare presentations| Projects                                       | Projects | SGC                   |
 |     |          |                      |                                                |          | Team retrospectives   |
-|5pm  | Workshops| Presentations        | Talk                                           | Projects | Talk                  |
+|5pm  | Better   | Presentations        | Talk                                           | Projects | Talk                  |
 |     |          |                      |                                                |          |                       | 
+|6pm  | Ends     |                      |                                                |          |                       | 

--- a/coursebook/schedules/london-default.md
+++ b/coursebook/schedules/london-default.md
@@ -1,0 +1,21 @@
+# London Programme default schedule, Weeks 1-8
+
+Start time | Day 1 | Day 2 | Day 3 | Day 4 | Day 5
+-- | -- | -- | -- | -- | --
+  |   |   |   |   |  
+10am | Workshops | Challenge | Challenge | Projects | Code review
+  |   |   |   |   |  
+11am | Workshops | Workshops | Projects | Projects | Review issues
+  |   |   |   |   |  
+12pm | Workshops | Workshops | Projects | Projects | Prepare presentations
+  |   |   |   |   |  
+1pm | Lunch | Lunch | Lunch | Lunch | Lunch
+  |   |   |   |   |  
+2pm | Workshops | Project intro | [Design burst](https://github.com/foundersandcoders/design-bursts) | Projects | Presentations
+  |   | Research intro | Projects |   |  
+3pm | Workshops | Research | Projects | Projects | Presentations
+  |   |   |   |   | SGC
+4pm | Workshops | Prepare presentations | Projects | Projects | SGC
+  |   |   |   |   | Team retrospectives
+5pm | Workshops | Presentations | Talk | Projects | Talk
+  |   |   |   |   |  

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -23,7 +23,7 @@
   - Introduce gitter channels
 - Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/pair-programming.md): 1hr
 - [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility/blob/master/putting-yourself-in-someone-elses-shoes.md): 1hr
-- [New Scavenger Hunt/Github tour?](): 30mins
+- [Github scavenger hunt](): 30mins (resource incoming)
 - [User Manuals](): 30mins (resource incoming)
 - [Introduction to consensus based decision-making](): 1hr (resource incoming)
 

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -1,79 +1,43 @@
 # Toolkit week
 
-## Menu
+## Contents
 
 - [Learning Outcomes](./learning-outcomes.md)
 - [Research topics](./research-afternoon.md)
 - [Project](./project.md)
 - [Resources](./resources)
 
+## Schedule
+- [Default schedule](../schedules/default.md)
+
 ## Day 1
 
-- 10.00 - 10.30 — Welcome talk
-- 10:30 - 11:30 — Name game with as many members of Founders and Coders as possible!
-- 11:30 - 11:40 - Toilet/Coffee Break
-- 11:40 - 13:00 - Course overview
+- [Welcome talk](https://facresources.com/slides/community-talk#/): 30mins
+- [Name Game](./resources/name-game.md): 1hr
+- Course Overview: 1hr
   - Go through 16 week [schedule](https://github.com/foundersandcoders/master-reference/tree/master/coursebook)
   - [Code of Conduct](https://github.com/foundersandcoders/master-reference/blob/master/code-of-conduct.md)
   - [House rules](../general/house-rules.md)
   - Students create their own [Cohort Code of Conduct](cohort-code-of-conduct.md)
   - Campus-specific info
   - Introduce gitter channels
-
-— LUNCH —
-
-- 14:00 - 14:50 — Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/pair-programming.md)
-- 14:50 - 15:00 — Toilet/Coffee Break
-- 15:00 - 16:00 — [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility/blob/master/putting-yourself-in-someone-elses-shoes.md)
-- 16.00 - 17.00 — [Github Scavenger Hunt - master reference](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/github-scavenger-hunt.md)  
-  Github Scavenger Hunt - campus specific  
-  [London](https://github.com/foundersandcoders/london-programme/blob/master/github-scavenger-hunt.md)  
-  [Nazareth](https://github.com/foundersandcoders/nazareth-programme/blob/master/github-scavenger-hunt.md)
-- 17:00 - 18:00 — Introduction to consensus based decision-making
+- Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/pair-programming.md): 1hr
+- [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility/blob/master/putting-yourself-in-someone-elses-shoes.md): 1hr
+- [New Scavenger Hunt/Github tour?](): 30mins
+- [User Manuals](): 30mins. (make a resource outside of fac15/16 etc.)
+- [Introduction to consensus based decision-making](): 1hr. (make a resource for cbdm??)
+#### 6.5hrs
 
 ## Day 2
 
-- 10:00 - 11:00 — Morning Challenge - [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge)
-- 11:00 - 13:00 — [Git workshop](https://github.com/foundersandcoders/git-workflow-workshop-for-two)
-
-— LUNCH —
-
-- 14:00 - 14:30 — Introduce [Project](./project.md)
-- 14:30 - 14:45 — Introduce [Research topics](./research-afternoon.md)
-- 14:45 - 15:00 — [Presentation Guidance](./presentation-guidance.md)
-- 15:00 - 17:00 — Research / TBC
-- 17.00 - 18:00 — Research presentations
+- Morning Challenge - [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge): 1hr
+- [Git workshop](https://github.com/foundersandcoders/git-workflow-workshop-for-two): 2hrs
+- Introduce [project](./project.md), [research topics](./research-afternoon.md) and [presentation guidance](./presentation-guidance.md): 30mins
+- [Research session](): 2hrs
+- [Research Presentations](): 1hr
+#### 6.5hrs
 
 ## Day 3
 
-- 10.00 - 11.00 — [Morning Challenge - CSS Gallery Challenge](https://github.com/foundersandcoders/css-gallery-challenge)
-- 11.00 - 13.00 — Projects
+- [Morning Challenge - CSS Gallery Challenge](https://github.com/foundersandcoders/css-gallery-challenge): 1hr
 
-— LUNCH —
-
-- 14.00 - 17.30 — Projects
-- 17.30 - 18.00 — [FAC Community talk](https://docs.google.com/presentation/d/1p-45WEiZ6QHacF9L-Xt1JwEpUrwgxHvLlgL5F-sw9os/edit?usp=sharing)
-
-## Day 4
-
-- 10.00 - 13.00 — Projects
-
-— LUNCH —
-
-- 14.00 - 18.00 — Projects
-
-## Day 5
-
-- 10:00 - 10:15 - How to Code review [here](./codereviewintro.md)
-- 10.15 - 11.00 — Code review (1 alumnus per project, 1 team reviews another team)
-- 11.00 - 13:00 — Respond to issues and [plan presentations](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/weekly-projects.md#project-presentation)
-
-— LUNCH —
-
-- 14:00-15:20 — Presentations (20 mins per group)
-
-- 15:20-16:20 — [Cohort Stop Go Continue (retrospective)](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/retrospectives.md#cohort-retrospective)
-
-- 16:20-17:00 — [Team retrospectives](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/retrospectives.md#team-retrospectives)
-
-- 17:00-18:00 — External Speaker or Alumni Project Presentation

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -24,8 +24,8 @@
 - Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/pair-programming.md): 1hr
 - [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility/blob/master/putting-yourself-in-someone-elses-shoes.md): 1hr
 - [New Scavenger Hunt/Github tour?](): 30mins
-- [User Manuals](): 30mins. (make a resource outside of fac15/16 etc.)
-- [Introduction to consensus based decision-making](): 1hr. (make a resource for cbdm??)
+- [User Manuals](): 30mins (resource incoming)
+- [Introduction to consensus based decision-making](): 1hr (resource incoming)
 
 
 ## Day 2

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -39,7 +39,7 @@
 
 - [Morning Challenge - CSS Gallery Challenge](https://github.com/foundersandcoders/css-gallery-challenge): 1hr
 
-### Day 5
+## Day 5
 - [How to code review](./codereviewintro.md)
 - [Intro to project presentations](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/weekly-projects.md#project-presentation)
 - [Intro to cohort Stop Go Continue](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/retrospectives.md#cohort-retrospective)

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -34,9 +34,6 @@
 
 - Morning Challenge - [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge): 1hr
 - [Git workshop](https://github.com/foundersandcoders/git-workflow-workshop-for-two): 2hrs
-- Introduce [project](./project.md), [research topics](./research-afternoon.md) and [presentation guidance](./presentation-guidance.md): 30mins
-- [Research session](): 2hrs
-- [Research Presentations](): 1hr
 #### 6.5hrs
 
 ---

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -28,6 +28,8 @@
 - [Introduction to consensus based decision-making](): 1hr. (make a resource for cbdm??)
 #### 6.5hrs
 
+---
+
 ## Day 2
 
 - Morning Challenge - [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge): 1hr
@@ -36,6 +38,8 @@
 - [Research session](): 2hrs
 - [Research Presentations](): 1hr
 #### 6.5hrs
+
+---
 
 ## Day 3
 

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -26,19 +26,22 @@
 - [New Scavenger Hunt/Github tour?](): 30mins
 - [User Manuals](): 30mins. (make a resource outside of fac15/16 etc.)
 - [Introduction to consensus based decision-making](): 1hr. (make a resource for cbdm??)
-#### 6.5hrs
 
----
 
 ## Day 2
 
 - Morning Challenge - [Accessibility challenge](https://github.com/foundersandcoders/accessibility-challenge): 1hr
 - [Git workshop](https://github.com/foundersandcoders/git-workflow-workshop-for-two): 2hrs
-#### 6.5hrs
+- [Research and Presentation Guidance](./presentation-guidance.md)
 
----
 
 ## Day 3
 
 - [Morning Challenge - CSS Gallery Challenge](https://github.com/foundersandcoders/css-gallery-challenge): 1hr
+
+### Day 5
+- [How to code review](./codereviewintro.md)
+- [Intro to project presentations](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/weekly-projects.md#project-presentation)
+- [Intro to cohort Stop Go Continue](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/retrospectives.md#cohort-retrospective)
+- [Into to team retrospectives](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/general/retrospectives.md#team-retrospectives)
 

--- a/coursebook/week-1/README.md
+++ b/coursebook/week-1/README.md
@@ -23,9 +23,9 @@
   - Introduce gitter channels
 - Introduction to [Pair Programming](https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/pair-programming.md): 1hr
 - [Accessibility Workshop](https://github.com/foundersandcoders/web-accessibility/blob/master/putting-yourself-in-someone-elses-shoes.md): 1hr
-- [Github scavenger hunt](): 30mins (resource incoming)
-- [User Manuals](): 30mins (resource incoming)
-- [Introduction to consensus based decision-making](): 1hr (resource incoming)
+- [Github scavenger hunt](./scavenger-hunt.md): 30mins
+- [User Manuals](../general/user-manuals.md): 30mins
+- [Introduction to consensus based decision-making](../general/decision-making.md): 1hr
 
 
 ## Day 2

--- a/coursebook/week-1/resources/name-game.md
+++ b/coursebook/week-1/resources/name-game.md
@@ -1,0 +1,3 @@
+# Name game
+
+[description to go here]

--- a/coursebook/week-1/scavenger-hunt.md
+++ b/coursebook/week-1/scavenger-hunt.md
@@ -1,0 +1,3 @@
+# Scavenger hunt
+
+[in progress]


### PR DESCRIPTION
Off the back of many discussions about the `master-reference`, and inspired by @m4v15's fork.

@sofer and I did some work on this yesterday. The premise is that there's a default schedule, which is (we think?) applicable at the moment to all campuses and all weeks, 1-8. Each week's `README.md` then lists the necessary resources, workshops, challenges etc. for that week, and the weekly mentors/CF for each campus can work them into the schedule to suit their needs. 

Would be great to have a discussion around this proposed new format. :seedling: 

Fixes #1012 