### PR TITLE
remove dead link

### DIFF
--- a/coursebook/schedules/default.md
+++ b/coursebook/schedules/default.md
@@ -18,6 +18,3 @@
 |6h  | Workshops | Presentations        | Talk                                           | Projects | Talk                  |
 |    |           |                      |                                                |          |                       |
 |7h  | Class ends|                      |                                                |          |                       |
-
-
-### [London default schedule](./london-default.md)


### PR DESCRIPTION
London schedule no longer exists so we should get rid of it!